### PR TITLE
Have workflow run only if code / CI changes.

### DIFF
--- a/.github/workflows/runAllChecks.yml
+++ b/.github/workflows/runAllChecks.yml
@@ -1,6 +1,20 @@
 name: Java CI
 
-on: [push, pull_request]
+on: 
+  push:
+    paths:
+      - 'src/**'
+      - 'gradle/**'
+      - 'config/**'
+      - '.github/**'
+      - 'build.gradle'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'gradle/**'
+      - 'config/**'
+      - '.github/**'
+      - 'build.gradle'
 
 jobs:
   build:

--- a/.github/workflows/runAllChecks.yml
+++ b/.github/workflows/runAllChecks.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: 
+on:
   push:
     paths:
       - 'src/**'


### PR DESCRIPTION
Currently it runs whenever anything changes (e.g. `/docs/index.md` ) 

It would waste time when making PRs that don't need this CI checks. (A future TP thing is setting up branch protection that requires PRs to pass all applicable CI checks before merging)

This limits the workflow to only run on changes to source code or configurations of CI actions.

I changed the file name from gradle.yml to runAllChecks.yml because the 'run-checks' and 'codecov-actions' that the CS2103t teaching team added to the file clearly does more than Gradle stuff.