### PR TITLE
Update GitHub CI for feature branch workflow.

### DIFF
--- a/.github/workflows/runAllChecks.yml
+++ b/.github/workflows/runAllChecks.yml
@@ -2,6 +2,9 @@ name: Java CI
 
 on:
   push:
+    branches:
+      - master
+      - 'dev/**'
     paths:
       - 'src/**'
       - 'gradle/**'
@@ -9,12 +12,16 @@ on:
       - '.github/**'
       - 'build.gradle'
   pull_request:
+    branches:
+      - master
+      - 'dev/**'
     paths:
       - 'src/**'
       - 'gradle/**'
       - 'config/**'
       - '.github/**'
       - 'build.gradle'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
The CI checks only need to automatically run on master and dev branches. To give developers the flexibility to have it run on their branches anyway, I've added a manual workflow dispatch option for any branch.

