### PR TITLE
Enable repo-wide checks for markdown files.

### DIFF
--- a/.github/workflows/repoWideChecksOnly.yml
+++ b/.github/workflows/repoWideChecksOnly.yml
@@ -1,0 +1,45 @@
+name: Repo Wide Checks
+
+on:
+  push:
+    branches:
+      - master
+      - 'dev/**'
+    paths-ignore:
+      - 'src/**'
+      - 'gradle/**'
+      - 'config/**'
+      - '.github/**'
+      - 'build.gradle'
+  pull_request:
+    branches:
+      - master
+      - 'dev/**'
+    paths-ignore:
+      - 'src/**'
+      - 'gradle/**'
+      - 'config/**'
+      - '.github/**'
+      - 'build.gradle'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@main
+
+      - name: Set up repository
+        uses: actions/checkout@main
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Run repository-wide tests
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/.github
+        run: ./run-checks.sh


### PR DESCRIPTION
Currently changes to `/docs/` folder does not trigger repo-wide checks for EOF new lines, trailing whitespace, illegal characters etc. This was because we optimised our github CI to run only on code-base changes.

This is a problem when changes to the `README.md` or `/docs/` folder cause checks to fail for code-base PR. In certain circumstances, see [PR #18](https://github.com/AY2122S1-CS2103T-W16-1/tp/pull/18), it is not even clear where the markdown change came in.

To prevent such situations, this will enable repo wide checks whenever there is a gap (ignoring all file change triggers that start the Java CI).