### PR TITLE
Support `Command` instructing `Ui`.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -3,6 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.function.Consumer;
+
+import seedu.address.ui.Ui;
 
 /**
  * Represents the result of a command execution.
@@ -11,19 +14,14 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    /** Help information should be shown to the user. */
-    private final boolean showHelp;
-
-    /** The application should exit. */
-    private final boolean exit;
+    private final Consumer<Ui> uiAction;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, Consumer<Ui> uiAction) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
+        this.uiAction = uiAction;
     }
 
     /**
@@ -31,19 +29,11 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, (ui -> { /* do nothing; */ }));
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
-    }
-
-    public boolean isShowHelp() {
-        return showHelp;
-    }
-
-    public boolean isExit() {
-        return exit;
     }
 
     @Override
@@ -59,13 +49,12 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && uiAction.equals(otherCommandResult.uiAction);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, uiAction);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -48,13 +48,16 @@ public class CommandResult {
         }
 
         CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && uiAction.equals(otherCommandResult.uiAction);
+        return feedbackToUser.equals(otherCommandResult.feedbackToUser);
+        // it is no longer possible to compare it on the basis of show help or exit
+        // due to the nature of lambdas.
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, uiAction);
+        return Objects.hash(feedbackToUser);
+        // it is no longer possible to compare it on the basis of show help or exit
+        // due to the nature of lambdas.
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import seedu.address.model.Model;
+import seedu.address.ui.Ui;
 
 /**
  * Terminates the program.
@@ -13,7 +14,6 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, (Ui::beginExit));
     }
-
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import seedu.address.model.Model;
+import seedu.address.ui.Ui;
 
 /**
  * Format full help instructions for every command for display.
@@ -16,6 +17,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, (Ui::showHelp));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -48,8 +48,10 @@ public class ViewCommand extends Command {
         }
         Person person = lastShownList.get(index.getZeroBased());
         PersonAdapter personToView = new PersonAdapter(model, person);
-        //TODO: Please do your magic Tee Chin
-        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, person.getName()));
+        String feedbackToUser = String.format(MESSAGE_VIEW_PERSON_SUCCESS, person.getName());
+        return new CommandResult(feedbackToUser, ui -> {
+            ui.showClientView(personToView);
+        });
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -154,7 +154,7 @@ public class MainWindow extends UiPart<Stage> {
      * Closes the application.
      */
     @FXML
-    private void handleExit() {
+    public void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
                 (int) primaryStage.getX(), (int) primaryStage.getY());
         uiManager.setGuiSettings(guiSettings);
@@ -176,14 +176,6 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = uiManager.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-
-            if (commandResult.isShowHelp()) {
-                handleHelp();
-            }
-
-            if (commandResult.isExit()) {
-                handleExit();
-            }
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/Ui.java
+++ b/src/main/java/seedu/address/ui/Ui.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import javafx.stage.Stage;
+import seedu.address.logic.PersonAdapter;
 
 /**
  * API of UI component
@@ -10,4 +11,9 @@ public interface Ui {
     /** Starts the UI (and the App).  */
     void start(Stage primaryStage);
 
+    void showHelp();
+
+    void beginExit();
+
+    void showClientView(PersonAdapter subject);
 }

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
+import seedu.address.logic.PersonAdapter;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -29,7 +30,7 @@ public class UiManager implements Ui {
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String ICON_APPLICATION = "/images/address_book_32.png";
 
-    private Logic logic;
+    private final Logic logic;
     private MainWindow mainWindow;
 
     /**
@@ -56,6 +57,21 @@ public class UiManager implements Ui {
             logger.severe(StringUtil.getDetails(e));
             showFatalErrorDialogAndShutdown("Fatal error during initializing", e);
         }
+    }
+
+    @Override
+    public void showHelp() {
+        this.mainWindow.handleHelp();
+    }
+
+    @Override
+    public void beginExit() {
+        this.mainWindow.handleExit();
+    }
+
+    @Override
+    public void showClientView(PersonAdapter subject) {
+
     }
 
     private Image getImage(String imagePath) {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import seedu.address.ui.Ui;
 
 public class CommandResultTest {
     @Test
@@ -14,7 +15,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback")));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -28,11 +29,8 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
 
-        // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
-
-        // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        // note that comparing CommandResult on the basis of their exit / show help is no longer possible.
+        // see CommandResult::hashcode and CommandResult::equals
     }
 
     @Test
@@ -45,10 +43,7 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
-        // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
-
-        // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        // note that comparing CommandResult on the basis of their exit / show help is no longer possible.
+        // see CommandResult::hashcode and CommandResult::equals
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import seedu.address.ui.Ui;
 
 public class CommandResultTest {
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -9,6 +9,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.ui.Ui;
 
 public class ExitCommandTest {
     private Model model = new ModelManager(new AddressBook(), new UserPrefs(), null);
@@ -16,7 +17,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, Ui::beginExit);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -9,6 +9,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.ui.Ui;
 
 public class HelpCommandTest {
     private Model model = new ModelManager(new AddressBook(), new UserPrefs(), null);
@@ -16,7 +17,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, Ui::showHelp);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Currently there is no way for `Command` to instruct `Ui` to show help,
exit (and in the upcoming use case, switch to `ClientView`). The former
two are currently done by passing data values (in boolean) to
`MainWindow` logic to handle. This is not a particularly clean way.
Furthermore, switching to `ClientView` (and eventually dealing with
todo, meetings and other front-end) requires a better way to instruct
Ui.

This commit will remove the earlier ways of instructing show help and
exit, and instead rely on a `Consumer<Ui>` field in `CommandResult` to
carry out instructions on `Ui`. This can be extended to handle current
and future `Ui` actions.

Fixes AY2122S1-CS2103T-W16-1/tp#66

## Checklist

- [x] Have you ensured [`./src/test`](./src/test) is up to date?
- [x] Have you added javadocs?
~~- [ ] Have you updated Dev Guide in [`./docs/`](./docs)?~~ Refer to #68 


