### PR TITLE
Add Error Handling & Simplify `AttributePanel`.

### DIFF
--- a/src/main/java/donnafin/ui/AttributePanel.java
+++ b/src/main/java/donnafin/ui/AttributePanel.java
@@ -13,7 +13,6 @@ import javafx.scene.shape.Rectangle;
 public class AttributePanel extends UiPart<Region> {
 
     private static final String FXML = "AttributePanel.fxml";
-    private String value;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -37,6 +36,7 @@ public class AttributePanel extends UiPart<Region> {
 
     private final EditHandler editor;
     private State state;
+    private String value;
 
     enum State {
         EDIT_MODE,
@@ -78,16 +78,15 @@ public class AttributePanel extends UiPart<Region> {
     }
 
     private void updateView(State intended) {
+        this.valueTextField.setText(this.value);
+        this.valueLabel.setText(this.value);
+
         if (intended == State.VIEW_MODE) {
-            this.valueTextField.setText(this.value);
-            this.valueLabel.setText(this.value);
             this.valueTextField.setOpacity(0);
             this.valueLabel.setOpacity(1);
             this.valueTextField.setEditable(false);
             this.state = State.VIEW_MODE;
         } else if (intended == State.EDIT_MODE) {
-            this.valueTextField.setText(this.value);
-            this.valueLabel.setText(this.value);
             this.valueTextField.setOpacity(1);
             this.valueLabel.setOpacity(0);
             this.valueTextField.setEditable(true);

--- a/src/main/java/donnafin/ui/AttributePanel.java
+++ b/src/main/java/donnafin/ui/AttributePanel.java
@@ -13,10 +13,10 @@ import javafx.scene.shape.Rectangle;
 /**
  * An UI component that displays information of a {@code Person}.
  */
-public class AttributePanel extends UiPart<Region> implements Attribute {
+public class AttributePanel extends UiPart<Region> {
 
     private static final String FXML = "AttributePanel.fxml";
-    private String field;
+    private final String field;
     private String value;
 
     /**
@@ -39,9 +39,7 @@ public class AttributePanel extends UiPart<Region> implements Attribute {
     @FXML
     private Rectangle focusOutline;
 
-    private final Attribute attribute;
-
-    private BiConsumer<PersonAdapter.PersonField, String> editor;
+    private final BiConsumer<PersonAdapter.PersonField, String> editor;
     private State state;
 
     enum State {
@@ -51,11 +49,12 @@ public class AttributePanel extends UiPart<Region> implements Attribute {
 
     /**
      * Constructor for Attribute panel
-     * @param attribute
+     *
+     * @param attribute used to identify values and field name.
+     * @param editor the callback used to commit changes to model.
      */
     public AttributePanel(Attribute attribute, BiConsumer<PersonAdapter.PersonField, String> editor) {
         super(FXML);
-        this.attribute = attribute;
         this.editor = editor;
         this.field = attribute.getClass().getSimpleName();
         this.value = attribute.toString();

--- a/src/main/java/donnafin/ui/AttributePanel.java
+++ b/src/main/java/donnafin/ui/AttributePanel.java
@@ -35,7 +35,7 @@ public class AttributePanel extends UiPart<Region> {
     private Rectangle focusOutline;
 
     private final EditHandler editor;
-    private State state;
+    private State state = State.VIEW_MODE;
     private String value;
 
     enum State {
@@ -74,26 +74,16 @@ public class AttributePanel extends UiPart<Region> {
         valueTextField.setText(this.value);
         valueTextField.focusedProperty().addListener((
             ignoreObservable, ignoreOldValue, newValue) -> focusOutline.setVisible(newValue));
-        updateView(State.VIEW_MODE);
+        setEditable(false);
     }
 
-    private void updateView(State intended) {
-        this.valueTextField.setText(this.value);
-        this.valueLabel.setText(this.value);
+    private void setEditable(boolean isToBeEditable) {
+        int textFieldOpacity = isToBeEditable ? 1 : 0;
+        int labelOpacity = isToBeEditable ? 0 : 1;
 
-        if (intended == State.VIEW_MODE) {
-            this.valueTextField.setOpacity(0);
-            this.valueLabel.setOpacity(1);
-            this.valueTextField.setEditable(false);
-            this.state = State.VIEW_MODE;
-        } else if (intended == State.EDIT_MODE) {
-            this.valueTextField.setOpacity(1);
-            this.valueLabel.setOpacity(0);
-            this.valueTextField.setEditable(true);
-            this.state = State.EDIT_MODE;
-        } else {
-            assert false : "Attribute Panel in an unexpected state";
-        }
+        this.valueTextField.setOpacity(textFieldOpacity);
+        this.valueLabel.setOpacity(labelOpacity);
+        this.valueTextField.setEditable(isToBeEditable);
     }
 
     /**
@@ -102,18 +92,23 @@ public class AttributePanel extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
+        this.value = valueTextField.getText();
+        this.valueTextField.setText(this.value);
+        this.valueLabel.setText(this.value);
+
         switch (this.state) {
         case EDIT_MODE:
-            this.value = valueTextField.getText();
             String errMessage = editor.applyEdit(this.value);
             if (errMessage != null) {
                 handleError(errMessage);
             } else {
-                updateView(State.VIEW_MODE);
+                setEditable(false);
+                this.state = State.VIEW_MODE;
             }
             break;
         case VIEW_MODE:
-            updateView(State.EDIT_MODE);
+            setEditable(true);
+            this.state = State.EDIT_MODE;
             break;
         default:
             assert false : "Attribute Panel in an unexpected state";

--- a/src/main/java/donnafin/ui/ClientInfoPanel.java
+++ b/src/main/java/donnafin/ui/ClientInfoPanel.java
@@ -1,16 +1,15 @@
 package donnafin.ui;
 
-import java.util.function.BiConsumer;
-
 import donnafin.logic.InvalidFieldException;
 import donnafin.logic.PersonAdapter;
+import donnafin.model.person.Attribute;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 public class ClientInfoPanel extends UiPart<Region> {
     private static final String FXML = "ClientInfoPanel.fxml";
-    private PersonAdapter personAdapter;
+    private final PersonAdapter personAdapter;
 
     @FXML
     private VBox clientInfoList;
@@ -22,15 +21,45 @@ public class ClientInfoPanel extends UiPart<Region> {
         super(FXML);
         this.personAdapter = personAdapter;
 
-        BiConsumer<PersonAdapter.PersonField, String> editor = (x, y) -> {
-            try {
-                personAdapter.edit(x, y);
-            } catch (InvalidFieldException e) {
-                e.printStackTrace();
-            }
-        };
         personAdapter.getAllAttributesList().stream()
-                .map(x -> new AttributePanel(x, editor).getRoot())
+                .map(attr -> createAttributePanel(attr).getRoot())
                 .forEach(y -> clientInfoList.getChildren().add(y));
     }
+
+    private AttributePanel createAttributePanel(Attribute attr) {
+        String fieldInString = attr.getClass().getSimpleName();
+        return new AttributePanel(
+                fieldInString,
+                attr.toString(),
+                createEditHandler(getPersonField(fieldInString))
+        );
+    }
+
+    /** Gets the PersonField enum type of attribute from label */
+    private PersonAdapter.PersonField getPersonField(String fieldInString) {
+        switch(fieldInString) {
+        case "Name":
+            return PersonAdapter.PersonField.NAME;
+        case "Address":
+            return PersonAdapter.PersonField.ADDRESS;
+        case "Phone":
+            return PersonAdapter.PersonField.PHONE;
+        case "Email":
+            return PersonAdapter.PersonField.EMAIL;
+        default:
+            throw new IllegalArgumentException("Unexpected Person Field used");
+        }
+    }
+
+    private AttributePanel.EditHandler createEditHandler(PersonAdapter.PersonField field) {
+        return newValue -> {
+            try {
+                this.personAdapter.edit(field, newValue);
+                return null;
+            } catch (InvalidFieldException e) {
+                return e.getMessage();
+            }
+        };
+    }
+
 }

--- a/src/main/java/donnafin/ui/ClientInfoPanel.java
+++ b/src/main/java/donnafin/ui/ClientInfoPanel.java
@@ -61,5 +61,4 @@ public class ClientInfoPanel extends UiPart<Region> {
             }
         };
     }
-
 }

--- a/src/main/resources/view/AttributePanel.fxml
+++ b/src/main/resources/view/AttributePanel.fxml
@@ -4,19 +4,19 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.Pane?>
+<?import javafx.scene.shape.Line?>
 <?import javafx.scene.shape.Rectangle?>
 
-<Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity"
-      minWidth="-Infinity" prefHeight="55.0" prefWidth="564.0" xmlns="http://javafx.com/javafx/16"
-      xmlns:fx="http://javafx.com/fxml/1">
+<Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="55.0" prefWidth="564.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Label fx:id="fieldLabel" layoutX="14.0" layoutY="2.0" prefHeight="46.0" prefWidth="98.0" text="Label" />
-      <TextField fx:id="valueTextField" layoutX="123.0" layoutY="8.0" onAction="#handleCommandEntered" prefHeight="36.0" prefWidth="432.0" />
-      <Label fx:id="valueLabel" layoutX="123.0" layoutY="9.0" prefHeight="36.0" prefWidth="432.0" text="Label">
+      <Rectangle fx:id="focusOutline" arcHeight="5.0" arcWidth="5.0" fill="#0000007f" height="47.0" layoutX="2.0" layoutY="2.0" stroke="#3d119600" strokeType="INSIDE" strokeWidth="8.0" visible="false" width="560.0" />
+      <Label fx:id="fieldLabel" layoutX="14.0" layoutY="10.0" prefHeight="36.0" prefWidth="98.0" styleClass="label-bright" text="Label" />
+      <TextField fx:id="valueTextField" layoutX="123.0" layoutY="10.0" onAction="#handleCommandEntered" prefHeight="36.0" prefWidth="432.0" />
+      <Label fx:id="valueLabel" layoutX="123.0" layoutY="10.0" prefHeight="36.0" prefWidth="432.0" styleClass="label-bright" text="Label">
          <padding>
             <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
          </padding>
       </Label>
-      <Rectangle fx:id="focusOutline" arcHeight="5.0" arcWidth="5.0" fill="#1f93ff00" height="55.0" stroke="#5900ff" strokeType="INSIDE" strokeWidth="8.0" visible="false" width="564.0" />
+      <Line endX="458.0" layoutX="104.0" layoutY="53.0" startX="-102.0" stroke="#a9a9a9" />
    </children>
 </Pane>


### PR DESCRIPTION
Fixes #96

- Simplifies `AttributePanel`
  - it does not need `Attribute` at all as it is just a view
  - Simplify the logic used in `ClientView` to create an `AttributePanel`
- Rather than a consumer for the edit, use a functional interface that returns useful error messages
- Support throwing an alert dialog when it edit fails.

## Checklist

- [x] Have you added javadocs?
