### PR TITLE
Make AttributePanel responsive.

### DIFF
--- a/src/main/java/donnafin/ui/AttributePanel.java
+++ b/src/main/java/donnafin/ui/AttributePanel.java
@@ -4,8 +4,8 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Region;
-import javafx.scene.shape.Rectangle;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -32,7 +32,7 @@ public class AttributePanel extends UiPart<Region> {
     private Label valueLabel;
 
     @FXML
-    private Rectangle focusOutline;
+    private AnchorPane anchorPane;
 
     private final EditHandler editor;
     private State state = State.VIEW_MODE;
@@ -72,9 +72,17 @@ public class AttributePanel extends UiPart<Region> {
         fieldLabel.setText(fieldInString);
         valueLabel.setText(this.value);
         valueTextField.setText(this.value);
-        valueTextField.focusedProperty().addListener((
-            ignoreObservable, ignoreOldValue, newValue) -> focusOutline.setVisible(newValue));
         setEditable(false);
+        valueTextField.focusedProperty().addListener((
+            ignoreObservable, ignoreOldValue, newValue) -> setHighlight(newValue));
+    }
+
+    private void setHighlight(boolean isOnFocus) {
+        if (isOnFocus) {
+            anchorPane.setStyle("-fx-background-color: rgba(0, 0, 0, 0.7)");
+        } else {
+            anchorPane.setStyle("-fx-background-color: rgba(0, 0, 0, 0)");
+        }
     }
 
     private void setEditable(boolean isToBeEditable) {

--- a/src/main/resources/view/AttributePanel.fxml
+++ b/src/main/resources/view/AttributePanel.fxml
@@ -3,20 +3,45 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.shape.Line?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.shape.Rectangle?>
 
-<Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="55.0" prefWidth="564.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<AnchorPane fx:id="anchorPane" maxWidth="1.7976931348623157E308" styleClass="attribute-panel" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Rectangle fx:id="focusOutline" arcHeight="5.0" arcWidth="5.0" fill="#0000007f" height="47.0" layoutX="2.0" layoutY="2.0" stroke="#3d119600" strokeType="INSIDE" strokeWidth="8.0" visible="false" width="560.0" />
-      <Label fx:id="fieldLabel" layoutX="14.0" layoutY="10.0" prefHeight="36.0" prefWidth="98.0" styleClass="label-bright" text="Label" />
-      <TextField fx:id="valueTextField" layoutX="123.0" layoutY="10.0" onAction="#handleCommandEntered" prefHeight="36.0" prefWidth="432.0" />
-      <Label fx:id="valueLabel" layoutX="123.0" layoutY="10.0" prefHeight="36.0" prefWidth="432.0" styleClass="label-bright" text="Label">
+      <Label fx:id="fieldLabel" prefHeight="55.0" prefWidth="100.0" styleClass="label-bright" text="Label">
+         <opaqueInsets>
+            <Insets />
+         </opaqueInsets>
          <padding>
-            <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
+            <Insets left="8.0" />
          </padding>
       </Label>
-      <Line endX="458.0" layoutX="104.0" layoutY="53.0" startX="-102.0" stroke="#a9a9a9" />
+      <HBox alignment="CENTER_LEFT" AnchorPane.bottomAnchor="2.0" AnchorPane.leftAnchor="8.0" AnchorPane.rightAnchor="8.0" AnchorPane.topAnchor="2.0">
+         <children>
+            <Rectangle arcHeight="5.0" arcWidth="5.0" fill="DODGERBLUE" height="55.0" stroke="BLACK" strokeType="INSIDE" visible="false" width="100.0" HBox.hgrow="ALWAYS" />
+            <Label fx:id="valueLabel" maxWidth="1.7976931348623157E308" styleClass="label-bright" text="InitialValue (Label)" HBox.hgrow="ALWAYS">
+               <padding>
+                  <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
+               </padding>
+               <HBox.margin>
+                  <Insets right="12.0" />
+               </HBox.margin>
+            </Label>
+         </children>
+      </HBox>
+      <HBox alignment="CENTER_LEFT" AnchorPane.bottomAnchor="2.0" AnchorPane.leftAnchor="8.0" AnchorPane.rightAnchor="8.0" AnchorPane.topAnchor="2.0">
+         <children>
+            <Rectangle arcHeight="5.0" arcWidth="5.0" fill="DODGERBLUE" height="55.0" stroke="BLACK" strokeType="INSIDE" visible="false" width="100.0" />
+            <TextField fx:id="valueTextField" maxWidth="1.7976931348623157E308" onAction="#handleCommandEntered" prefHeight="36.0" promptText="sdfdsf" text="InitialValue (TextField)" HBox.hgrow="ALWAYS">
+               <HBox.margin>
+                  <Insets right="12.0" />
+               </HBox.margin>
+            </TextField>
+         </children>
+         <opaqueInsets>
+            <Insets />
+         </opaqueInsets>
+      </HBox>
    </children>
-</Pane>
+</AnchorPane>

--- a/src/main/resources/view/ClientInfoPanel.fxml
+++ b/src/main/resources/view/ClientInfoPanel.fxml
@@ -4,12 +4,11 @@
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.VBox?>
 
-
-<TabPane xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<TabPane maxWidth="1.7976931348623157E308" prefWidth="800.0" tabMaxWidth="140.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
    <tabs>
       <Tab closable="false" text="Client Information">
          <content>
-            <VBox fx:id="clientInfoTab" >
+            <VBox fx:id="clientInfoTab">
                 <VBox fx:id="clientInfoList" VBox.vgrow="ALWAYS" />
             </VBox>
          </content>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -157,6 +157,11 @@
     -fx-text-fill: black !important;
 }
 
+.attribute-panel {
+    -fx-border-color: #a9a9a9;
+    -fx-border-width: 0 0 2 0;
+}
+
 .status-bar .label {
     -fx-font-family: "Open Sans Light";
     -fx-text-fill: white;


### PR DESCRIPTION
Fixes #98 

Previously, `AttributePanel` would not resize with a window change.

Use JavaFX AnchorPane and using proper background fill and bottom
border instead of Rectangle & Line shape objects (enables responsive
resizing based on the parent container).

Placed this within `AttributePanel` logic (`setHighlight()`) to
more neatly present the SE logic to developers.

## Checklist

- [x] Have you added javadocs?
