### PR TITLE
Support testing for Notes.

### DIFF
--- a/src/main/java/donnafin/model/person/Person.java
+++ b/src/main/java/donnafin/model/person/Person.java
@@ -100,13 +100,14 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
-                && otherPerson.getTags().equals(getTags());
+                && otherPerson.getTags().equals(getTags())
+                && otherPerson.getNotes().equals(getNotes());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, notes);
     }
 
     @Override
@@ -125,6 +126,8 @@ public class Person {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
         }
+
+        builder.append("; Notes: ").append(getNotes());
         return builder.toString();
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,7 +5,8 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "notes": "Loves cai fan"
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",

--- a/src/test/java/donnafin/logic/PersonAdapterTest.java
+++ b/src/test/java/donnafin/logic/PersonAdapterTest.java
@@ -21,6 +21,7 @@ import donnafin.model.UserPrefs;
 import donnafin.model.person.Address;
 import donnafin.model.person.Email;
 import donnafin.model.person.Name;
+import donnafin.model.person.Notes;
 import donnafin.model.person.Person;
 import donnafin.model.person.Phone;
 import donnafin.model.tag.Tag;
@@ -163,5 +164,18 @@ public class PersonAdapterTest {
         personAdapter.edit(PersonAdapter.PersonField.TAGS, "friends");
         assertEquals(ALICE, personAdapter.getSubject());
 
+    }
+
+    @Test
+    public void editPersonNotes_changesSubject() throws InvalidFieldException {
+        personAdapter.edit(PersonAdapter.PersonField.NOTES, "Loves cai fan & teh ping");
+        Notes modifiedNotes = new Notes("Loves cai fan & teh ping");
+
+        assertEquals(new Person(ALICE.getName(), ALICE.getPhone(), ALICE.getEmail(),
+                ALICE.getAddress(), ALICE.getTags(), modifiedNotes), personAdapter.getSubject());
+        assertNotEquals(ALICE, personAdapter.getSubject());
+
+        personAdapter.edit(PersonAdapter.PersonField.NOTES, "Loves cai fan");
+        assertEquals(ALICE, personAdapter.getSubject());
     }
 }

--- a/src/test/java/donnafin/testutil/PersonBuilder.java
+++ b/src/test/java/donnafin/testutil/PersonBuilder.java
@@ -51,6 +51,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        notes = personToCopy.getNotes();
     }
 
     /**
@@ -90,6 +91,12 @@ public class PersonBuilder {
      */
     public PersonBuilder withEmail(String email) {
         this.email = new Email(email);
+        return this;
+    }
+
+    /** Sets the {@code Notes} of the {@code Person} that we are building. */
+    public PersonBuilder withNotes(String notes) {
+        this.notes = new Notes(notes);
         return this;
     }
 

--- a/src/test/java/donnafin/testutil/TypicalPersons.java
+++ b/src/test/java/donnafin/testutil/TypicalPersons.java
@@ -25,8 +25,7 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
-            .withTags("friends").build();
+            .withPhone("94351253").withTags("friends").withNotes("Loves cai fan").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")


### PR DESCRIPTION
Previously, notes field was entirely ignored by the tests.
This was because `Person` did not compare notes when running
`hashCode()` or `equals()`

Add logic to update all of this, and update the tests to follow
suit.