### PR TITLE
Delete `./data` when running `clean` Gradle task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+clean.doFirst {
+    delete "${rootDir}/data/"
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
Currently, the existing addressbook data is not wiped when we run the
clean task on Gradle.

Clean task is expected to carry out all necessary changes to the folder
to show a fresh start. This must include data as well, which is
autogenerated on first run and edited and saved on user input.

Add to `build.gradle` to do additional action of deleting the folder  on
top of existing default actions in the Gradle task `clean`.

Fixes #131 