### PR TITLE
Bhcs/add money and integrate with sheehui

### DIFF
--- a/src/main/java/donnafin/commons/core/types/Index.java
+++ b/src/main/java/donnafin/commons/core/types/Index.java
@@ -1,4 +1,4 @@
-package donnafin.commons.core.index;
+package donnafin.commons.core.types;
 
 /**
  * Represents a zero-based or one-based index.

--- a/src/main/java/donnafin/commons/core/types/Money.java
+++ b/src/main/java/donnafin/commons/core/types/Money.java
@@ -49,7 +49,9 @@ public class Money {
         String biggerUnitValue = "" + absVal / divisor;
         String sign = absVal == value ? " " : "-";
 
-        int numDigitsSmallerValue = (int) Math.floor(Math.log10(absVal % divisor)) + 1;
+        int numDigitsSmallerValue = absVal % divisor != 0
+                ? (int) Math.floor(Math.log10(absVal % divisor)) + 1
+                : 1;
         String smallerUnitValue = "0".repeat(Math.max(0, fractionDigits - numDigitsSmallerValue));
         smallerUnitValue += absVal % divisor;
 

--- a/src/main/java/donnafin/commons/core/types/Money.java
+++ b/src/main/java/donnafin/commons/core/types/Money.java
@@ -1,0 +1,120 @@
+package donnafin.commons.core.types;
+
+import java.util.Currency;
+import java.util.Objects;
+
+import donnafin.commons.exceptions.IllegalValueException;
+
+public class Money {
+    public static final String MONEY_MISMATCH_CURRENCY =
+            "Arithmetic on different currencies is not supported.";
+    public static final String MONEY_ARITHMETIC_OVERFLOW =
+            "Unable to calculate due to Integer limitations.";
+    private static final Currency DEFAULT_CURRENCY = Currency.getInstance("SGD");
+
+    private final int value;
+    private final Currency currency;
+
+    /**
+     * Create a Money object with value and currency as specified.
+     *
+     * @param valueInSmallestUnit integer value of the currency in its smallest unit (e.g. cent)
+     */
+    public Money(int valueInSmallestUnit) {
+        this(valueInSmallestUnit, Money.DEFAULT_CURRENCY);
+    }
+
+    /**
+     * Create a Money object with value and currency as specified.
+     *
+     * @param valueInSmallestUnit integer value of the currency in its smallest unit (e.g. cent)
+     * @param currency the currency being used (SGD if omitted).
+     */
+    public Money(int valueInSmallestUnit, Currency currency) {
+        Objects.requireNonNull(currency);
+        this.value = valueInSmallestUnit;
+        this.currency = currency;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        int fractionDigits = this.currency.getDefaultFractionDigits();
+        int absVal = Math.abs(value);
+        int divisor = (int) Math.pow(10, fractionDigits);
+
+        String biggerUnitValue = "" + absVal / divisor;
+        String sign = absVal == value ? " " : "-";
+
+        int numDigitsSmallerValue = (int) Math.floor(Math.log10(absVal % divisor)) + 1;
+        String smallerUnitValue = "0".repeat(Math.max(0, fractionDigits - numDigitsSmallerValue));
+        smallerUnitValue += absVal % divisor;
+
+        return String.format("%s%s %s.%s", sign, currency.getSymbol(), biggerUnitValue, smallerUnitValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Money)) {
+            return false;
+        }
+        Money money = (Money) o;
+        return value == money.value && currency.equals(money.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, currency);
+    }
+
+    /**
+     * Perform addition on Money objects.
+     *
+     * @return result of adding two Money objects of the same currency.
+     * @throws MoneyException if the Money objects involved are of different currencies or
+     *                        results in an ArithmeticError (Integer overflow).
+     */
+    public static Money add(Money a, Money b) throws MoneyException {
+        if (!(a.currency.equals(b.currency))) {
+            throw new MoneyException(Money.MONEY_MISMATCH_CURRENCY);
+        }
+        try {
+            return new Money(Math.addExact(a.value, b.value));
+        } catch (ArithmeticException e) {
+            throw new MoneyException(Money.MONEY_ARITHMETIC_OVERFLOW);
+        }
+    }
+
+    /**
+     * Perform subtraction on Money objects.
+     *
+     * @return result of adding two Money objects of the same currency.
+     * @throws MoneyException if the Money objects involved are of different currencies or
+     *                        results in an ArithmeticError (Integer overflow).
+     */
+    public static Money subtract(Money a, Money b) throws MoneyException {
+        if (!(a.currency.equals(b.currency))) {
+            throw new MoneyException(Money.MONEY_MISMATCH_CURRENCY);
+        }
+        try {
+            return new Money(Math.subtractExact(a.value, b.value));
+        } catch (ArithmeticException e) {
+            throw new MoneyException(Money.MONEY_ARITHMETIC_OVERFLOW);
+        }
+    }
+
+    public static class MoneyException extends IllegalValueException {
+        /**
+         * @param message should contain relevant information on the failed constraint(s)
+         */
+        public MoneyException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/donnafin/logic/PersonAdapter.java
+++ b/src/main/java/donnafin/logic/PersonAdapter.java
@@ -1,9 +1,12 @@
 package donnafin.logic;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import donnafin.logic.parser.ParserUtil;
+import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.Model;
 import donnafin.model.person.Address;
 import donnafin.model.person.Asset;
@@ -65,7 +68,7 @@ public class PersonAdapter {
             Person newPerson = editPerson(curr, field, newValue);
             this.subject = newPerson;
             model.setPerson(curr, newPerson);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | ParseException e) {
             throw new InvalidFieldException(field);
         }
     }
@@ -78,7 +81,7 @@ public class PersonAdapter {
         return subject.getPersonalAttributesList();
     }
 
-    private Person editPerson(Person personToEdit, PersonField field, String newValue) {
+    private Person editPerson(Person personToEdit, PersonField field, String newValue) throws ParseException {
         switch (field) {
         case NAME:
             return editPersonName(personToEdit, newValue);
@@ -198,28 +201,13 @@ public class PersonAdapter {
                 personToEdit.getAssets());
     }
 
-
-    /**
-     * Converts String representative of a policy to {@code Policy}.
-     *
-     * @param policyString String representative of a policy.
-     * @return A Policy
-     */
-    private Policy stringToPolicy(String policyString) {
-        String[] details = policyString.split(ATTRIBUTE_DELIMITER);
-        //@parserteam do error handling for this
-        //        if (details != 5) {
-        //            throw new ParseException(Policy.MESSAGE_CONSTRAINTS);
-        //        }
-
-        return new Policy(details);
-    }
-
-    private Person editPersonPolicies(Person personToEdit, String newValue) {
+    private Person editPersonPolicies(Person personToEdit, String newValue) throws ParseException {
         String[] policiesStrings = newValue.split(SET_DELIMITER);
-        Set<Policy> newPolicies = Arrays.stream(policiesStrings)
-                .map(this::stringToPolicy)
-                .collect(Collectors.toSet());
+        Set<Policy> newPolicies = new HashSet<>();
+        for (String policiesString : policiesStrings) {
+            Policy policy = ParserUtil.parsePolicy(policiesString);
+            newPolicies.add(policy);
+        }
 
         return new Person(
                 personToEdit.getName(),
@@ -233,27 +221,13 @@ public class PersonAdapter {
                 personToEdit.getAssets());
     }
 
-    /**
-     * Converts String representative of a liability to a {@code Liability}.
-     *
-     * @param liabilityString String representative of liability.
-     * @return A Liability.
-     */
-    private Liability stringToLiability(String liabilityString) {
-        String[] details = liabilityString.split(ATTRIBUTE_DELIMITER);
-        //@parserteam do error handling for this
-        //        if (details != 4) {
-        //            throw new ParseException(Liability.MESSAGE_CONSTRAINTS);
-        //        }
-
-        return new Liability(details);
-    }
-
-    private Person editPersonLiabilities(Person personToEdit, String newValue) {
+    private Person editPersonLiabilities(Person personToEdit, String newValue) throws ParseException {
         String[] liabilitiesStrings = newValue.split(ATTRIBUTE_DELIMITER);
-        Set<Liability> newLiabilities = Arrays.stream(liabilitiesStrings)
-                .map(this::stringToLiability)
-                .collect(Collectors.toSet());
+        Set<Liability> newLiabilities = new HashSet<>();
+        for (String liabilitiesString : liabilitiesStrings) {
+            Liability liability = ParserUtil.parseLiability(liabilitiesString);
+            newLiabilities.add(liability);
+        }
 
         return new Person(
                 personToEdit.getName(),
@@ -267,27 +241,13 @@ public class PersonAdapter {
                 personToEdit.getAssets());
     }
 
-    /**
-     * Converts String representative of an asset to a {@code Asset}.
-     *
-     * @param assetString String representative of an asset.
-     * @return An Asset.
-     */
-    private Asset stringToAsset(String assetString) {
-        String[] details = assetString.split(ATTRIBUTE_DELIMITER);
-        //@parserteam do error handling for this
-        //        if (details != 4) {
-        //            throw new ParseException(Asset.MESSAGE_CONSTRAINTS);
-        //        }
-
-        return new Asset(details);
-    }
-
-    private Person editPersonAssets(Person personToEdit, String newValue) {
+    private Person editPersonAssets(Person personToEdit, String newValue) throws ParseException {
         String[] assetsStrings = newValue.split(SET_DELIMITER);
-        Set<Asset> newAssets = Arrays.stream(assetsStrings)
-                .map(this::stringToAsset)
-                .collect(Collectors.toSet());
+        Set<Asset> newAssets = new HashSet<>();
+        for (String assetsString : assetsStrings) {
+            Asset asset = ParserUtil.parseAsset(assetsString);
+            newAssets.add(asset);
+        }
 
         return new Person(
                 personToEdit.getName(),

--- a/src/main/java/donnafin/logic/commands/DeleteCommand.java
+++ b/src/main/java/donnafin/logic/commands/DeleteCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.logic.commands.exceptions.CommandException;
 import donnafin.model.Model;
 import donnafin.model.person.Person;

--- a/src/main/java/donnafin/logic/commands/ViewCommand.java
+++ b/src/main/java/donnafin/logic/commands/ViewCommand.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.logic.PersonAdapter;
 import donnafin.logic.commands.exceptions.CommandException;
 import donnafin.model.Model;
@@ -45,9 +45,7 @@ public class ViewCommand extends Command {
         Person person = lastShownList.get(index.getZeroBased());
         PersonAdapter personToView = new PersonAdapter(model, person);
         String feedbackToUser = String.format(MESSAGE_VIEW_PERSON_SUCCESS, person.getName());
-        return new CommandResult(feedbackToUser, ui -> {
-            ui.showClientView(personToView);
-        });
+        return new CommandResult(feedbackToUser, ui -> ui.showClientView(personToView));
     }
 
     @Override

--- a/src/main/java/donnafin/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/donnafin/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,7 @@
 package donnafin.logic.parser;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.logic.commands.DeleteCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.commons.util.StringUtil;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.person.Address;

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -2,10 +2,8 @@ package donnafin.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import donnafin.commons.core.types.Index;
@@ -137,14 +135,15 @@ public class ParserUtil {
      */
     public static Policy parsePolicy(String policy) throws ParseException {
         String[] details = policy.split(ATTRIBUTE_DELIMITER);
-        Arrays.stream(details).map(Objects::requireNonNull);
 
-        String trimmedPolicy = policy.trim();
-        if (!Policy.isValidPolicy(trimmedPolicy) || details.length != 5) {
+        if (details.length != 5) {
             throw new ParseException(Policy.MESSAGE_CONSTRAINTS);
         }
-
-        return new Policy(details);
+        try {
+            return new Policy(details[0], details[1], details[2], details[3], details[4]);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(Policy.MESSAGE_CONSTRAINTS);
+        }
     }
 
     /**
@@ -169,13 +168,15 @@ public class ParserUtil {
      */
     public static Asset parseAsset(String asset) throws ParseException {
         String[] details = asset.split(ATTRIBUTE_DELIMITER);
-        Arrays.stream(details).map(Objects::requireNonNull);
 
-        String trimmedAsset = asset.trim();
-        if (!Asset.isValidAsset(trimmedAsset) || details.length != 4) {
+        if (details.length != 4) {
             throw new ParseException(Asset.MESSAGE_CONSTRAINTS);
         }
-        return new Asset(details);
+        try {
+            return new Asset(details[0], details[1], details[2], details[3]);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(Policy.MESSAGE_CONSTRAINTS);
+        }
     }
 
     /**
@@ -184,7 +185,6 @@ public class ParserUtil {
     public static Set<Asset> parseAssets(Collection<String> assets) throws ParseException {
         requireNonNull(assets);
         final Set<Asset> assetSet = new HashSet<>();
-
         for (String assetName : assets) {
             assetSet.add(parseAsset(assetName));
         }
@@ -201,14 +201,15 @@ public class ParserUtil {
      */
     public static Liability parseLiability(String liability) throws ParseException {
         String[] details = liability.split(ATTRIBUTE_DELIMITER);
-        Arrays.stream(details).map(Objects::requireNonNull);
 
-        String trimmedLiability = liability.trim();
-        if (!Liability.isValidLiability(trimmedLiability) || details.length != 4) {
+        if (details.length != 4) {
+            throw new ParseException(Asset.MESSAGE_CONSTRAINTS);
+        }
+        try {
+            return new Liability(details[0], details[1], details[2], details[3]);
+        } catch (IllegalArgumentException e) {
             throw new ParseException(Liability.MESSAGE_CONSTRAINTS);
         }
-
-        return new Liability(details);
     }
 
     /**

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import donnafin.commons.core.types.Index;
+import donnafin.commons.core.types.Money;
 import donnafin.commons.util.StringUtil;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.person.Address;
@@ -224,4 +225,27 @@ public class ParserUtil {
         return liabilitySet;
     }
 
+    /**
+     * Parses a {@code String money} into a {@code Money}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code String money} is invalid.
+     */
+    public static Money parseMoney(String money) throws ParseException {
+        requireNonNull(money);
+        String trimmedCommission = money.trim();
+
+        // Handling Default currency $XYZ or $XYZ.AB
+        final String regexDollarCents = "^-?\\s*\\$\\s*\\d+(\\.\\d{2})?$";
+        final String dollarCentsPrefix = "$";
+        final int dollarCentsToSmallUnit = 100;
+
+        if (trimmedCommission.matches(regexDollarCents)) {
+            String decimalString = trimmedCommission.replace(dollarCentsPrefix, "").replace(" ", "");
+            double value = Double.parseDouble(decimalString);
+            return new Money((int) (value * dollarCentsToSmallUnit));
+        } else {
+            throw new ParseException("Input string does not match any monetary value format.");
+        }
+    }
 }

--- a/src/main/java/donnafin/logic/parser/ViewCommandParser.java
+++ b/src/main/java/donnafin/logic/parser/ViewCommandParser.java
@@ -1,7 +1,7 @@
 package donnafin.logic.parser;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.logic.commands.ViewCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/donnafin/model/person/Asset.java
+++ b/src/main/java/donnafin/model/person/Asset.java
@@ -2,8 +2,11 @@ package donnafin.model.person;
 
 import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Arrays;
 import java.util.Objects;
+
+import donnafin.commons.core.types.Money;
+import donnafin.logic.parser.ParserUtil;
+import donnafin.logic.parser.exceptions.ParseException;
 
 /**
  * Represents a Person's assets in DonnaFin.
@@ -14,7 +17,7 @@ public class Asset implements Attribute {
     public static final String VALIDATION_REGEX = "[\\s\\S]*";
     public final String name;
     public final String type;
-    public final String value;
+    public final Money value;
     public final String remarks;
 
     /**
@@ -29,28 +32,12 @@ public class Asset implements Attribute {
         requireAllNonNull(name, type, value, remarks);
         this.name = name;
         this.type = type;
-        this.value = value;
+        try {
+            this.value = ParserUtil.parseMoney(value);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(Policy.MESSAGE_CONSTRAINTS);
+        }
         this.remarks = remarks;
-    }
-
-    /**
-     * Constructs a {@code Asset} with an array input.
-     *
-     * @param details Array containing all fields of new Asset.
-     */
-    public Asset(String[] details) {
-        Arrays.stream(details).map(Objects::requireNonNull);
-        this.name = details[0];
-        this.type = details[1];
-        this.value = details[2];
-        this.remarks = details[3];
-    }
-
-    /**
-     * Returns true if a given string is a valid asset name
-     */
-    public static boolean isValidAsset(String test) {
-        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Liability.java
+++ b/src/main/java/donnafin/model/person/Liability.java
@@ -2,8 +2,11 @@ package donnafin.model.person;
 
 import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Arrays;
 import java.util.Objects;
+
+import donnafin.commons.core.types.Money;
+import donnafin.logic.parser.ParserUtil;
+import donnafin.logic.parser.exceptions.ParseException;
 
 /**
  * Represents a Person's liability in DonnaFin.
@@ -11,10 +14,9 @@ import java.util.Objects;
 public class Liability implements Attribute {
 
     public static final String MESSAGE_CONSTRAINTS = "Insert liability constraint here";
-    public static final String VALIDATION_REGEX = "[\\s\\S]*";
     public final String name;
     public final String type;
-    public final String value;
+    public final Money value;
     public final String remarks;
 
     /**
@@ -29,28 +31,12 @@ public class Liability implements Attribute {
         requireAllNonNull(name, type, value, remarks);
         this.name = name;
         this.type = type;
-        this.value = value;
+        try {
+            this.value = ParserUtil.parseMoney(value);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(Policy.MESSAGE_CONSTRAINTS);
+        }
         this.remarks = remarks;
-    }
-
-    /**
-     * Constructs a {@code Liability} with an array input.
-     *
-     * @param details Array containing all fields of new Liability.
-     */
-    public Liability(String[] details) {
-        Arrays.stream(details).map(Objects::requireNonNull);
-        this.name = details[0];
-        this.type = details[1];
-        this.value = details[2];
-        this.remarks = details[3];
-    }
-
-    /**
-     * Returns true if a given string is a valid liability name
-     */
-    public static boolean isValidLiability(String test) {
-        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Policy.java
+++ b/src/main/java/donnafin/model/person/Policy.java
@@ -4,6 +4,10 @@ import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import donnafin.commons.core.types.Money;
+import donnafin.logic.parser.ParserUtil;
+import donnafin.logic.parser.exceptions.ParseException;
+
 /**
  * Represents a Person's policy in DonnaFin.
  */
@@ -13,9 +17,9 @@ public class Policy implements Attribute {
     public static final String VALIDATION_REGEX = "[\\s\\S]*";
     public final String name;
     public final String insurer;
-    public final String totalValueInsured;
-    public final String yearlyPremiums;
-    public final String commission;
+    public final Money totalValueInsured;
+    public final Money yearlyPremiums;
+    public final Money commission;
 
     /**
      * Constructs a {@code Policy}.
@@ -30,29 +34,13 @@ public class Policy implements Attribute {
         requireAllNonNull(name, insurer, totalValueInsured, yearlyPremiums, commission);
         this.name = name;
         this.insurer = insurer;
-        this.totalValueInsured = totalValueInsured;
-        this.yearlyPremiums = yearlyPremiums;
-        this.commission = commission;
-    }
-
-    /**
-     * Constructs a {@code Policy} with an array input.
-     *
-     * @param details Array containing all fields of new Policy.
-     */
-    public Policy(String[] details) {
-        this.name = details[0];
-        this.insurer = details[1];
-        this.totalValueInsured = details[2];
-        this.yearlyPremiums = details[3];
-        this.commission = details[4];
-    }
-
-    /**
-     * Returns true if a given string is a valid policy name
-     */
-    public static boolean isValidPolicy(String test) {
-        return test.matches(VALIDATION_REGEX);
+        try {
+            this.totalValueInsured = ParserUtil.parseMoney(totalValueInsured);
+            this.yearlyPremiums = ParserUtil.parseMoney(yearlyPremiums);
+            this.commission = ParserUtil.parseMoney(commission);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException(Policy.MESSAGE_CONSTRAINTS);
+        }
     }
 
     @Override

--- a/src/main/java/donnafin/model/util/SampleDataUtil.java
+++ b/src/main/java/donnafin/model/util/SampleDataUtil.java
@@ -1,9 +1,14 @@
 package donnafin.model.util;
 
+import static donnafin.commons.util.AppUtil.checkArgument;
+
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import donnafin.logic.parser.ParserUtil;
+import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.AddressBook;
 import donnafin.model.ReadOnlyAddressBook;
 import donnafin.model.person.Address;
@@ -17,57 +22,72 @@ import donnafin.model.person.Phone;
 import donnafin.model.person.Policy;
 import donnafin.model.tag.Tag;
 
-
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
     private static final String ATTRIBUTE_DELIMITER = ";;;";
+    private static final String POLICIES_STAND_IN = String.join(
+            ATTRIBUTE_DELIMITER,
+            "Policy name",
+            "Policy insurer",
+            "$14000",
+            "$28",
+            "$4"
+    );
+    private static final String ASSETS_STAND_IN = String.join(
+            ATTRIBUTE_DELIMITER,
+            "asset name",
+            "asset type",
+            "$90.00",
+            "asset remarks"
+    );
+    private static final String LIABILITIES_STAND_IN = String.join(
+            ATTRIBUTE_DELIMITER,
+            "liability name:",
+            "liability type",
+            "$42.01",
+            "liability remarks"
+    );
 
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                     new Address("Blk 30 Geylang Street 29, #06-40"),
                     getTagSet("friends"), new Notes("Likes bread"),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN)),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     getTagSet("colleagues", "friends"), new Notes("Has 2 children"),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN)),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                     getTagSet("neighbours"), new Notes(""),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN)),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     getTagSet("family"), new Notes(""),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN)),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Address("Blk 47 Tampines Street 20, #17-35"),
                     getTagSet("classmates"), new Notes(""),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN)),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Address("Blk 45 Aljunied Street 85, #11-31"),
                     getTagSet("colleagues"), new Notes(""),
-                    getPolicies("Policy name;;;Policy insurer;;;policy total value insured;;;policy yearly "
-                            + "premiums;;;policy commission"),
-                    getLiabilities("liability name;;;liability type;;;liability value;;;liability remarks"),
-                    getAssets("asset name;;;asset type;;;asset value;;;asset remarks")),
+                    getPolicies(POLICIES_STAND_IN),
+                    getLiabilities(LIABILITIES_STAND_IN),
+                    getAssets(ASSETS_STAND_IN))
         };
     }
 
@@ -92,26 +112,50 @@ public class SampleDataUtil {
      * Returns a policy set containing the list of strings given.
      */
     public static Set<Policy> getPolicies(String... strings) {
-        return Arrays.stream(strings)
-                .map(x -> new Policy(x.split(ATTRIBUTE_DELIMITER)))
-                .collect(Collectors.toSet());
+        Set<Policy> set = new HashSet<>();
+        for (String x : strings) {
+            Policy policy = null;
+            try {
+                policy = ParserUtil.parsePolicy(x);
+            } catch (ParseException e) {
+                checkArgument(false, Policy.MESSAGE_CONSTRAINTS);
+            }
+            set.add(policy);
+        }
+        return set;
     }
 
     /**
      * Returns an asset set containing the list of strings given.
      */
     public static Set<Asset> getAssets(String... strings) {
-        return Arrays.stream(strings)
-                .map(x -> new Asset(x.split(ATTRIBUTE_DELIMITER)))
-                .collect(Collectors.toSet());
+        Set<Asset> set = new HashSet<>();
+        for (String x : strings) {
+            Asset asset = null;
+            try {
+                asset = ParserUtil.parseAsset(x);
+            } catch (ParseException e) {
+                checkArgument(false, Asset.MESSAGE_CONSTRAINTS);
+            }
+            set.add(asset);
+        }
+        return set;
     }
 
     /**
      * Returns a liability set containing the list of strings given.
      */
     public static Set<Liability> getLiabilities(String... strings) {
-        return Arrays.stream(strings)
-                .map(x -> new Liability(x.split(ATTRIBUTE_DELIMITER)))
-                .collect(Collectors.toSet());
+        Set<Liability> set = new HashSet<>();
+        for (String x : strings) {
+            Liability liability = null;
+            try {
+                liability = ParserUtil.parseLiability(x);
+            } catch (ParseException e) {
+                checkArgument(false, Liability.MESSAGE_CONSTRAINTS);
+            }
+            set.add(liability);
+        }
+        return set;
     }
 }

--- a/src/main/java/donnafin/storage/JsonAdaptedAsset.java
+++ b/src/main/java/donnafin/storage/JsonAdaptedAsset.java
@@ -33,7 +33,7 @@ class JsonAdaptedAsset {
      */
     public JsonAdaptedAsset(Asset source) {
         assetName = source.name;
-        assetValue = source.value;
+        assetValue = source.value.toString();
         assetType = source.type;
         assetRemarks = source.remarks;
     }
@@ -64,9 +64,6 @@ class JsonAdaptedAsset {
      * @throws IllegalValueException if there were any data constraints violated in the adapted assets.
      */
     public Asset toModelType() throws IllegalValueException {
-        if (!Asset.isValidAsset(assetName)) {
-            throw new IllegalValueException(Asset.MESSAGE_CONSTRAINTS);
-        }
         return new Asset(assetName, assetType, assetValue, assetRemarks);
     }
 

--- a/src/main/java/donnafin/storage/JsonAdaptedLiability.java
+++ b/src/main/java/donnafin/storage/JsonAdaptedLiability.java
@@ -31,7 +31,7 @@ public class JsonAdaptedLiability {
     public JsonAdaptedLiability(Liability source) {
         liabilityName = source.name;
         liabilityType = source.type;
-        liabilityValue = source.value;
+        liabilityValue = source.value.toString();
         liabilityRemarks = source.remarks;
     }
 
@@ -61,9 +61,6 @@ public class JsonAdaptedLiability {
      * @throws IllegalValueException if there were any data constraints violated in the adapted liability.
      */
     public Liability toModelType() throws IllegalValueException {
-        if (!Liability.isValidLiability(liabilityName)) {
-            throw new IllegalValueException(Liability.MESSAGE_CONSTRAINTS);
-        }
         return new Liability(liabilityName, liabilityType, liabilityValue, liabilityRemarks);
     }
 }

--- a/src/main/java/donnafin/storage/JsonAdaptedPolicy.java
+++ b/src/main/java/donnafin/storage/JsonAdaptedPolicy.java
@@ -39,9 +39,9 @@ class JsonAdaptedPolicy {
     public JsonAdaptedPolicy(Policy source) {
         policyName = source.name;
         policyInsurer = source.insurer;
-        policyYearlyPremiums = source.yearlyPremiums;
-        policyTotalValueInsured = source.totalValueInsured;
-        policyCommission = source.commission;
+        policyYearlyPremiums = source.yearlyPremiums.toString();
+        policyTotalValueInsured = source.totalValueInsured.toString();
+        policyCommission = source.commission.toString();
     }
 
     @JsonProperty("name")
@@ -75,9 +75,6 @@ class JsonAdaptedPolicy {
      * @throws IllegalValueException if there were any data constraints violated in the adapted policy.
      */
     public Policy toModelType() throws IllegalValueException {
-        if (!Policy.isValidPolicy(policyName)) {
-            throw new IllegalValueException(Policy.MESSAGE_CONSTRAINTS);
-        }
         return new Policy(policyName, policyInsurer, policyTotalValueInsured, policyYearlyPremiums, policyCommission);
     }
 }

--- a/src/test/java/donnafin/commons/core/types/IndexTest.java
+++ b/src/test/java/donnafin/commons/core/types/IndexTest.java
@@ -1,4 +1,4 @@
-package donnafin.commons.core.index;
+package donnafin.commons.core.types;
 
 import static donnafin.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/donnafin/commons/core/types/MoneyTest.java
+++ b/src/test/java/donnafin/commons/core/types/MoneyTest.java
@@ -15,6 +15,15 @@ public class MoneyTest {
     }
 
     @Test
+    public void checkMoneyOutput() {
+        assertEquals(" $ 1.00", new Money(100).toString());
+        assertEquals(" $ 3.00", new Money(300).toString());
+        assertEquals("-$ 1.00", new Money(-100).toString());
+        assertEquals(" $ 1.20", new Money(120).toString());
+        assertEquals(" $ 1.23", new Money(123).toString());
+    }
+
+    @Test
     public void testFullCentsString() {
         assertEquals(" $ 1.23", new Money(123).toString());
         assertEquals("-$ 1.23", new Money(-123).toString());

--- a/src/test/java/donnafin/commons/core/types/MoneyTest.java
+++ b/src/test/java/donnafin/commons/core/types/MoneyTest.java
@@ -1,0 +1,72 @@
+package donnafin.commons.core.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MoneyTest {
+
+    @Test
+    public void getMoneyFromIntegerCheckValue() {
+        assertEquals(123, new Money(123).getValue());
+        assertEquals(-123, new Money(-123).getValue());
+    }
+
+    @Test
+    public void testFullCentsString() {
+        assertEquals(" $ 1.23", new Money(123).toString());
+        assertEquals("-$ 1.23", new Money(-123).toString());
+    }
+
+    @Test
+    public void testPaddedCentsString() {
+        assertEquals(" $ 1.03", new Money(103).toString());
+        assertEquals("-$ 1.03", new Money(-103).toString());
+    }
+
+    @Test
+    public void testOnlyCentsString() {
+        assertEquals(" $ 0.03", new Money(3).toString());
+        assertEquals("-$ 0.03", new Money(-3).toString());
+    }
+
+    @Test
+    public void mathTest() throws Money.MoneyException {
+        Money oneCent = new Money(1);
+        Money oneDollar = new Money(100);
+        assertEquals(101, Money.add(oneCent, oneDollar).getValue());
+        assertEquals(99, Money.subtract(oneDollar, oneCent).getValue());
+        assertEquals(-99, Money.subtract(oneCent, oneDollar).getValue());
+    }
+
+    @Test
+    public void safeMaths() {
+        Money maxValue = new Money(Integer.MAX_VALUE);
+        Money minValue = new Money(Integer.MIN_VALUE);
+        Money oneCent = new Money(1);
+        assertThrows(Money.MoneyException.class, () -> Money.add(maxValue, oneCent));
+        assertThrows(Money.MoneyException.class, () -> Money.subtract(minValue, oneCent));
+    }
+
+    @Test
+    public void equals() {
+        Money oneDollar = new Money(100);
+        Money oneDollarAgain = new Money(100);
+        Money negativeOneDollar = new Money(-100);
+        Money negativeOneDollarAgain = new Money(-100);
+
+        assertEquals(oneDollar, oneDollar);
+        assertEquals(oneDollar, oneDollarAgain);
+        assertEquals(oneDollar.getValue(), oneDollarAgain.getValue());
+        assertEquals(oneDollar.toString(), oneDollarAgain.toString());
+
+        assertNotEquals(negativeOneDollar, oneDollar);
+
+        assertEquals(negativeOneDollar, negativeOneDollar);
+        assertEquals(negativeOneDollar, negativeOneDollarAgain);
+        assertEquals(negativeOneDollar.getValue(), negativeOneDollarAgain.getValue());
+        assertEquals(negativeOneDollar.toString(), negativeOneDollarAgain.toString());
+    }
+}

--- a/src/test/java/donnafin/logic/commands/CommandTestUtil.java
+++ b/src/test/java/donnafin/logic/commands/CommandTestUtil.java
@@ -49,10 +49,8 @@ public class CommandTestUtil {
 
     public static final String VALID_LIABILITY_AMY = "property debt;;;debt;;;$500000;;;downgrade imminent";
     public static final String VALID_LIABILITY_BOB = "company debt;;;debt;;;$100000;;;downgrade imminent";
-    public static final String VALID_POLICIES_ONE = "Diamond;;;AIA;;;$100000;;;cake;;;10%";
-    public static final String VALID_POLICIES_TWO = "policy two";
+    public static final String VALID_POLICIES_ONE = "Diamond;;;AIA;;;$100000;;;$20;;;$1";
     public static final String VALID_ASSET_ONE = "bitcoin;;;crypto;;;$10000000;;;mad stonks";
-    public static final String VALID_ASSET_TWO = "asset two";
 
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;

--- a/src/test/java/donnafin/logic/commands/CommandTestUtil.java
+++ b/src/test/java/donnafin/logic/commands/CommandTestUtil.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.logic.commands.exceptions.CommandException;
 import donnafin.model.AddressBook;
 import donnafin.model.Model;

--- a/src/test/java/donnafin/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/donnafin/logic/commands/DeleteCommandTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.model.Model;
 import donnafin.model.ModelManager;
 import donnafin.model.UserPrefs;

--- a/src/test/java/donnafin/logic/commands/ViewCommandTest.java
+++ b/src/test/java/donnafin/logic/commands/ViewCommandTest.java
@@ -7,7 +7,7 @@ import static donnafin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.Messages;
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.model.AddressBook;
 import donnafin.model.Model;
 import donnafin.model.ModelManager;

--- a/src/test/java/donnafin/logic/parser/ParserUtilTest.java
+++ b/src/test/java/donnafin/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import donnafin.commons.core.types.Money;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.person.Address;
 import donnafin.model.person.Email;
@@ -192,5 +193,75 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseMoney_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMoney(null));
+    }
+
+    @Test
+    public void parseMoney_validWithDollarSign() throws ParseException {
+        assertEquals(new Money(100), ParserUtil.parseMoney("$1"));
+        assertEquals(new Money(100000), ParserUtil.parseMoney("$1000"));
+    }
+
+    @Test
+    public void parseMoney_validWithDollarSignCents() throws ParseException {
+        assertEquals(new Money(105), ParserUtil.parseMoney("$1.05"));
+    }
+
+    @Test
+    public void parseMoney_invalidWithoutDollarSign() throws ParseException {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.05"));
+    }
+
+    @Test
+    public void parseMoney_validWithWhiteSpace() throws ParseException {
+        // trailing whitespace
+        assertEquals(new Money(100), ParserUtil.parseMoney("  $1  "));
+        assertEquals(new Money(105), ParserUtil.parseMoney("  $1.05  "));
+
+        // whitespace after dollar sign
+        assertEquals(new Money(100), ParserUtil.parseMoney("  $  1"));
+        assertEquals(new Money(105), ParserUtil.parseMoney("  $    1.05"));
+    }
+
+    @Test
+    public void parseMoney_validWithNegative() throws ParseException {
+        // trailing whitespace
+        assertEquals(new Money(-100), ParserUtil.parseMoney("-$1"));
+        assertEquals(new Money(-105), ParserUtil.parseMoney("-$1.05"));
+
+        // whitespace after dollar sign
+        assertEquals(new Money(-100), ParserUtil.parseMoney("-$1"));
+        assertEquals(new Money(-105), ParserUtil.parseMoney("-$1.05"));
+    }
+
+    @Test
+    public void parseMoney_validWithNegativeAndWhiteSpace() throws ParseException {
+        // trailing whitespace
+        assertEquals(new Money(-100), ParserUtil.parseMoney(" - $1  "));
+        assertEquals(new Money(-105), ParserUtil.parseMoney(" - $1.05  "));
+
+        // whitespace after dollar sign
+        assertEquals(new Money(-100), ParserUtil.parseMoney("  -  $  1"));
+        assertEquals(new Money(-105), ParserUtil.parseMoney(" -  $    1.05"));
+    }
+
+    @Test
+    public void parseMoney_invalidFormats() throws ParseException {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.00$"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.0.0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney(".50"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("abc $2.50"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("$2.50 abc"));
+    }
+
+    @Test
+    public void parseMoney_invalidWithWrongPrecision() throws ParseException {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.000"));
     }
 }

--- a/src/test/java/donnafin/testutil/TestUtil.java
+++ b/src/test/java/donnafin/testutil/TestUtil.java
@@ -5,7 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 import donnafin.model.Model;
 import donnafin.model.person.Person;
 

--- a/src/test/java/donnafin/testutil/TypicalIndexes.java
+++ b/src/test/java/donnafin/testutil/TypicalIndexes.java
@@ -1,6 +1,6 @@
 package donnafin.testutil;
 
-import donnafin.commons.core.index.Index;
+import donnafin.commons.core.types.Index;
 
 /**
  * A utility class containing a list of {@code Index} objects to be used in tests.


### PR DESCRIPTION
## Use `Money` in `Asset`, `Liability`, `Policy`. 0a118eee4338a84ae4792c28f5b5bbea4a917173 (HEAD)
Date:   Mon Oct 18 21:47:04 2021 +0800

Over the course of using `Money` as a type, I found multiple issues
wrt to exceptions. Note that these `Attribute` classes often throw
IllegalArgumentException (Runtime exception, unchecked). I followed
this for the new `Attribute`s as well to keep it consistent.

In addition, I dropped all the `stringToAttributeX` in `personAdapter`
as it doesn't really make sense in that, and shifted that
responsibility to `ParserUtil` as it hould have been.

## Add creation of `Money` from strings: `ParserUtil` d114b2efb94b10b694d532ca071a5104715fe743
Date:   Mon Oct 18 14:34:22 2021 +0800

Done with test driven development, so testing is also complete.

## Add `Money` and `MoneyTest` for monetary values. 705bc2da44478f94313fcc65bf7907e429313a74
Date:   Mon Oct 18 01:20:40 2021 +0800

## Refactor `donnafin.commons.core.index` -> `..core.types` a1abd76cf60c08f2e034f4c68aa7d83a027213ac
Date:   Sun Oct 17 22:36:40 2021 +0800

In preparation for upcoming dollar value.s
