### PR TITLE
Add test to ensure `SampleDataUtil` builds.

### DIFF
--- a/src/test/java/donnafin/model/util/SampleDataUtilTest.java
+++ b/src/test/java/donnafin/model/util/SampleDataUtilTest.java
@@ -1,0 +1,16 @@
+package donnafin.model.util;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import donnafin.model.ReadOnlyAddressBook;
+
+public class SampleDataUtilTest {
+
+    @Test
+    public void ensureSampleDataUtilCanInstantiate() {
+        ReadOnlyAddressBook addressBook = SampleDataUtil.getSampleAddressBook();
+        Objects.requireNonNull(addressBook);
+    }
+}


### PR DESCRIPTION
If `SampleDataUtil` is not built correctly, this will fail.
It is important that `SampleDataUtil` works so that new users with no address book sees a sample list of clients.

Fixes #178 