### PR TITLE
Lots of minor bugs squashed.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -352,6 +352,15 @@ If your changes to the data file makes its format invalid, DonnaFin will discard
 **Q**: How do I transfer my data to another Computer?<br>
 **A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous DonnaFin home folder.
 
+**Q**: I have multiple clients with the same name, but your application won't let me add them! What do I do?
+**A**: We realise some names are common, but we decided to prioritise your ability to instantly recognise a client over letting you keep the accuracy of the name. For that reason, we suggest adding other identifying nicknames or words in the name e.g. "John Walker (Bartender)" and "John Walker (Johnny)".
+
+**Q**: My clients have assets and policies valued in USD / RMB / AUD / other currency. How can I show this in the table?
+**A**: We plan to have multi-currency support in future developments. However, currently we only accept dollar ('$') currencies and formats that are compatible with the Singapore Dollar. For now, please use only a single currency and convert as appropriate.
+
+**Q**: I want to write with non-latin alphabets. Do you have support for internationalization (e.g. Chinese, Hindi, Malay)
+**A**: While it may not break our system, we have developed this application with latin script in mind, and cannot guarantee a bug-free experience.
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary

--- a/src/main/java/donnafin/commons/core/GuiSettings.java
+++ b/src/main/java/donnafin/commons/core/GuiSettings.java
@@ -10,8 +10,8 @@ import java.util.Objects;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = 720;
+    private static final double DEFAULT_WIDTH = 1024;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/donnafin/logic/parser/AppendCommandParser.java
+++ b/src/main/java/donnafin/logic/parser/AppendCommandParser.java
@@ -107,7 +107,7 @@ public class AppendCommandParser implements Parser<AppendCommand> {
             value = ParserUtil.parseMoney(argMultimap.getValue(PREFIX_VALUE).orElseThrow());
             remarks = argMultimap.getValue(PREFIX_REMARKS).orElse("");
         } catch (NoSuchElementException e) {
-            throw new ParseException(Asset.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Liability.MESSAGE_CONSTRAINTS);
         }
 
         Liability newLiability = null;

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -237,22 +237,22 @@ public class ParserUtil {
      */
     public static Money parseMoney(String money) throws ParseException {
         requireNonNull(money);
-        String trimmedCommission = money.trim();
+        String trimmedInput = money.trim();
 
         // Handling Default currency $XYZ or $XYZ.AB
         final String regexDollarCents = "^\\s*\\$\\s*\\d+(\\.\\d{2})?$";
         final String dollarCentsPrefix = "$";
 
-        if (!trimmedCommission.matches(regexDollarCents)) {
+        if (!trimmedInput.matches(regexDollarCents)) {
             throw new ParseException(
                     String.format(
                             "Input string '%s' does not match monetary value format. %s",
-                            trimmedCommission,
+                            trimmedInput,
                             Money.MESSAGE_CONSTRAINTS)
             );
         }
 
-        String decimalString = trimmedCommission.replace(dollarCentsPrefix, "").replace(" ", "");
+        String decimalString = trimmedInput.replace(dollarCentsPrefix, "").replace(" ", "");
         if (!decimalString.contains(".")) {
             decimalString += ".00";
         }
@@ -263,7 +263,7 @@ public class ParserUtil {
             throw new ParseException(e.getMessage());
         } catch (NumberFormatException e) {
             throw new ParseException(
-                    String.format("Input string '%s' exceeds maximum monetary value.", trimmedCommission));
+                String.format("'%s' exceeds maximum monetary value (~$92 quadrillion).", trimmedInput));
         }
     }
 

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -240,25 +240,30 @@ public class ParserUtil {
         String trimmedCommission = money.trim();
 
         // Handling Default currency $XYZ or $XYZ.AB
-        final String regexDollarCents = "^-?\\s*\\$\\s*\\d+(\\.\\d{2})?$";
+        final String regexDollarCents = "^\\s*\\$\\s*\\d+(\\.\\d{2})?$";
         final String dollarCentsPrefix = "$";
 
-        if (trimmedCommission.matches(regexDollarCents)) {
-            String decimalString = trimmedCommission.replace(dollarCentsPrefix, "").replace(" ", "");
-            if (!decimalString.contains(".")) {
-                decimalString += ".00";
-            }
-            long value;
-            try {
-                value = Long.parseLong(decimalString.replace(".", ""));
-            } catch (NumberFormatException e) {
-                throw new ParseException(
-                        String.format("Input string '%s' exceeds maximum monetary value.", trimmedCommission));
-            }
-            return new Money(value);
-        } else {
+        if (!trimmedCommission.matches(regexDollarCents)) {
             throw new ParseException(
-                    String.format("Input string '%s' does not match any monetary value format.", trimmedCommission));
+                    String.format(
+                            "Input string '%s' does not match monetary value format. %s",
+                            trimmedCommission,
+                            Money.MESSAGE_CONSTRAINTS)
+            );
+        }
+
+        String decimalString = trimmedCommission.replace(dollarCentsPrefix, "").replace(" ", "");
+        if (!decimalString.contains(".")) {
+            decimalString += ".00";
+        }
+        try {
+            long value = Long.parseLong(decimalString.replace(".", ""));
+            return new Money(value);
+        } catch (Money.MoneyException e) {
+            throw new ParseException(e.getMessage());
+        } catch (NumberFormatException e) {
+            throw new ParseException(
+                    String.format("Input string '%s' exceeds maximum monetary value.", trimmedCommission));
         }
     }
 

--- a/src/main/java/donnafin/model/person/Asset.java
+++ b/src/main/java/donnafin/model/person/Asset.java
@@ -2,6 +2,10 @@ package donnafin.model.person;
 
 import static donnafin.commons.util.AppUtil.checkArgument;
 import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
+import static donnafin.logic.parser.CliSyntax.PREFIX_NAME;
+import static donnafin.logic.parser.CliSyntax.PREFIX_REMARKS;
+import static donnafin.logic.parser.CliSyntax.PREFIX_TYPE;
+import static donnafin.logic.parser.CliSyntax.PREFIX_VALUE;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -17,8 +21,16 @@ import donnafin.ui.AttributeTable;
  */
 public class Asset implements Attribute {
 
-    public static final String MESSAGE_CONSTRAINTS = "Asset fields should not start with empty spaces or contain "
-            + "new lines.";
+    public static final String MESSAGE_CONSTRAINTS = "Assets must be specified with "
+            + "a name (non-empty string) "
+            + "a type (non-empty string) "
+            + "a value (positive monetary value) "
+            + "a remark (non-empty string) "
+            + "\nE.g. "
+            + PREFIX_NAME + "GCB at Dempsey Rd "
+            + PREFIX_TYPE + "Property "
+            + PREFIX_VALUE + "$10000000 "
+            + PREFIX_REMARKS + "unoccupied";
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final AttributeTable.TableConfig<Asset> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Assets",

--- a/src/main/java/donnafin/model/person/Asset.java
+++ b/src/main/java/donnafin/model/person/Asset.java
@@ -35,10 +35,10 @@ public class Asset implements Attribute {
     public static final AttributeTable.TableConfig<Asset> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Assets",
         List.of(
-                new AttributeTable.ColumnConfig("Asset Name", "name", 300),
-                new AttributeTable.ColumnConfig("Type", "type", 100),
-                new AttributeTable.ColumnConfig("Value", "valueToString", 100),
-                new AttributeTable.ColumnConfig("Remarks", "remarks", 100)
+                new AttributeTable.ColumnConfig("Asset Name", "name", 300, 500),
+                new AttributeTable.ColumnConfig("Type", "type", 100, 250),
+                new AttributeTable.ColumnConfig("Value", "valueToString", 100, 250),
+                new AttributeTable.ColumnConfig("Remarks", "remarks", 100, 250)
         ),
         assetCol -> assetCol.stream()
             .map(Asset::getValue)

--- a/src/main/java/donnafin/model/person/Email.java
+++ b/src/main/java/donnafin/model/person/Email.java
@@ -28,7 +28,7 @@ public class Email implements Attribute {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/main/java/donnafin/model/person/Liability.java
+++ b/src/main/java/donnafin/model/person/Liability.java
@@ -2,6 +2,10 @@ package donnafin.model.person;
 
 import static donnafin.commons.util.AppUtil.checkArgument;
 import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
+import static donnafin.logic.parser.CliSyntax.PREFIX_NAME;
+import static donnafin.logic.parser.CliSyntax.PREFIX_REMARKS;
+import static donnafin.logic.parser.CliSyntax.PREFIX_TYPE;
+import static donnafin.logic.parser.CliSyntax.PREFIX_VALUE;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -17,8 +21,16 @@ import donnafin.ui.AttributeTable;
  */
 public class Liability implements Attribute {
 
-    public static final String MESSAGE_CONSTRAINTS = "Liability fields should not start with empty spaces or "
-            + "contain new lines.";
+    public static final String MESSAGE_CONSTRAINTS = "Liability must be specified with "
+            + "a name (non-empty string) "
+            + "a type (non-empty string) "
+            + "a value (positive monetary value) "
+            + "a remark (non-empty string) "
+            + "\nE.g. "
+            + PREFIX_NAME + "DBS loan for Dempsey Rd unit "
+            + PREFIX_TYPE + "Property Mortgage "
+            + PREFIX_VALUE + "$420 "
+            + PREFIX_REMARKS + "mostly paid off ";
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final AttributeTable.TableConfig<Liability> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Liabilities",

--- a/src/main/java/donnafin/model/person/Liability.java
+++ b/src/main/java/donnafin/model/person/Liability.java
@@ -35,10 +35,10 @@ public class Liability implements Attribute {
     public static final AttributeTable.TableConfig<Liability> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Liabilities",
         List.of(
-                new AttributeTable.ColumnConfig("Liability Name", "name", 300),
-                new AttributeTable.ColumnConfig("Type", "type", 100),
-                new AttributeTable.ColumnConfig("Value", "valueToString", 100),
-                new AttributeTable.ColumnConfig("Remarks", "remarks", 100)
+                new AttributeTable.ColumnConfig("Liability Name", "name", 300, 500),
+                new AttributeTable.ColumnConfig("Type", "type", 100, 250),
+                new AttributeTable.ColumnConfig("Value", "valueToString", 100, 250),
+                new AttributeTable.ColumnConfig("Remarks", "remarks", 100, 250)
         ),
         liabilityCol -> liabilityCol.stream()
             .map(Liability::getValue)

--- a/src/main/java/donnafin/model/person/Policy.java
+++ b/src/main/java/donnafin/model/person/Policy.java
@@ -2,6 +2,11 @@ package donnafin.model.person;
 
 import static donnafin.commons.util.AppUtil.checkArgument;
 import static donnafin.commons.util.CollectionUtil.requireAllNonNull;
+import static donnafin.logic.parser.CliSyntax.PREFIX_COMMISSION;
+import static donnafin.logic.parser.CliSyntax.PREFIX_INSURED_VALUE;
+import static donnafin.logic.parser.CliSyntax.PREFIX_INSURER;
+import static donnafin.logic.parser.CliSyntax.PREFIX_NAME;
+import static donnafin.logic.parser.CliSyntax.PREFIX_YEARLY_PREMIUM;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -17,8 +22,18 @@ import donnafin.ui.AttributeTable;
  */
 public class Policy implements Attribute {
 
-    public static final String MESSAGE_CONSTRAINTS = "Policy name and insurer should not contain new lines or "
-            + "start with empty spaces.";
+    public static final String MESSAGE_CONSTRAINTS = "Policies must be specified with "
+            + "a name (non-empty string) "
+            + "a insurer name (non-empty string) "
+            + "a value insured (positive monetary value) "
+            + "a yearly premium (positive monetary value) "
+            + "a commission (positive monetary value) "
+            + "\nE.g. "
+            + PREFIX_NAME + "Platinum Years "
+            + PREFIX_INSURER + "FinAssurance Corp. "
+            + PREFIX_INSURED_VALUE + "$100000 "
+            + PREFIX_YEARLY_PREMIUM + "$100 "
+            + PREFIX_COMMISSION + "$10 ";
     public static final String VALIDATION_REGEX = "[^\\s].*";
     public static final AttributeTable.TableConfig<Policy> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Policies",

--- a/src/main/java/donnafin/model/person/Policy.java
+++ b/src/main/java/donnafin/model/person/Policy.java
@@ -38,11 +38,11 @@ public class Policy implements Attribute {
     public static final AttributeTable.TableConfig<Policy> TABLE_CONFIG = new AttributeTable.TableConfig<>(
         "Policies",
         List.of(
-                    new AttributeTable.ColumnConfig("Policy Name", "name", 300),
-                    new AttributeTable.ColumnConfig("Insurer", "insurer", 100),
-                    new AttributeTable.ColumnConfig("Insured Value", "totalValueInsuredToString", 100),
-                    new AttributeTable.ColumnConfig("Premium (yearly)", "yearlyPremiumsToString", 100),
-                    new AttributeTable.ColumnConfig("Commission", "commissionToString", 100)
+                    new AttributeTable.ColumnConfig("Policy Name", "name", 200, 500),
+                    new AttributeTable.ColumnConfig("Insurer", "insurer", 100, 250),
+                    new AttributeTable.ColumnConfig("Insured Value", "totalValueInsuredToString", 200, 300),
+                    new AttributeTable.ColumnConfig("Premium (yearly)", "yearlyPremiumsToString", 200, 300),
+                    new AttributeTable.ColumnConfig("Commission", "commissionToString", 100, 250)
             ),
         policyCol -> policyCol.stream()
             .map(Policy::getCommission)

--- a/src/main/java/donnafin/ui/AttributeTable.java
+++ b/src/main/java/donnafin/ui/AttributeTable.java
@@ -29,7 +29,8 @@ public class AttributeTable<T> extends UiPart<Region> {
     public static class ColumnConfig {
         final String heading;
         final String propertyName;
-        final int minWidth;
+        final int maxWidth;
+        final int prefWidth;
 
         /**
          * Create a column config for use in the {@code AttributeTable}.
@@ -40,10 +41,11 @@ public class AttributeTable<T> extends UiPart<Region> {
          * @param propertyName name of the variable (must have a public getter function too)
          * @param minWidth in pixels
          */
-        public ColumnConfig(String heading, String propertyName, int minWidth) {
+        public ColumnConfig(String heading, String propertyName, int prefWidth, int maxWidth) {
             this.heading = heading;
             this.propertyName = propertyName;
-            this.minWidth = minWidth;
+            this.maxWidth = maxWidth;
+            this.prefWidth = prefWidth;
         }
     }
 
@@ -105,7 +107,7 @@ public class AttributeTable<T> extends UiPart<Region> {
 
         //@@author bharathcs-reused
         //Reused from https://stackoverflow.com/a/31213320/4179939 with minor modifications.
-        TableColumn<T, String> indexCol = new TableColumn<>("No.");
+        TableColumn<T, String> indexCol = new TableColumn<>("");
         indexCol.setCellFactory(col -> {
             TableCell<T, String> cell = new TableCell<>();
             cell.textProperty().bind(Bindings.createStringBinding(() -> {
@@ -120,13 +122,14 @@ public class AttributeTable<T> extends UiPart<Region> {
         //@@author
 
         List<TableColumn<T, String>> columns = new ArrayList<>();
-        indexCol.setMaxWidth(100);
+        indexCol.setMinWidth(40);
+        indexCol.setMaxWidth(40);
         columns.add(indexCol);
 
         for (ColumnConfig columnConfig : tableConfig.columnConfigs) {
             TableColumn<T, String> col = new TableColumn<>(columnConfig.heading);
-            col.setMinWidth(columnConfig.minWidth);
-            col.setMaxWidth(600);
+            col.setPrefWidth(columnConfig.prefWidth);
+            col.setMaxWidth(columnConfig.maxWidth);
             col.setCellValueFactory(new PropertyValueFactory<>(columnConfig.propertyName));
             columns.add(col);
         }

--- a/src/main/java/donnafin/ui/AttributeTable.java
+++ b/src/main/java/donnafin/ui/AttributeTable.java
@@ -130,6 +130,7 @@ public class AttributeTable<T> extends UiPart<Region> {
             col.setCellValueFactory(new PropertyValueFactory<>(columnConfig.propertyName));
             columns.add(col);
         }
+        columns.forEach(col -> col.setSortable(false));
 
         aggregatorLabel.setText(tableConfig.aggregatorLabelCreator.applyOn(collection));
 

--- a/src/main/java/donnafin/ui/MainWindow.java
+++ b/src/main/java/donnafin/ui/MainWindow.java
@@ -86,10 +86,6 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
     }
 
-    public StackPane getViewFinderPlaceholder() {
-        return this.viewFinderPlaceholder;
-    }
-
     /**
      * Sets the accelerator of a MenuItem.
      * @param keyCombination the KeyCombination value of the accelerator
@@ -190,10 +186,6 @@ public class MainWindow extends UiPart<Stage> {
         uiManager.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
-    }
-
-    public PersonListPanel getPersonListPanel() {
-        return personListPanel;
     }
 
     /**

--- a/src/test/java/donnafin/commons/core/types/MoneyTest.java
+++ b/src/test/java/donnafin/commons/core/types/MoneyTest.java
@@ -1,81 +1,74 @@
 package donnafin.commons.core.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import donnafin.commons.core.types.Money.MoneyException;
+
 public class MoneyTest {
 
     @Test
-    public void getMoneyFromIntegerCheckValue() {
+    public void getMoneyFromIntegerCheckValue() throws MoneyException {
         assertEquals(123, new Money(123).getValue());
-        assertEquals(-123, new Money(-123).getValue());
     }
 
     @Test
-    public void checkMoneyOutput() {
-        assertEquals(" $ 1.00", new Money(100).toString());
-        assertEquals(" $ 3.00", new Money(300).toString());
-        assertEquals("-$ 1.00", new Money(-100).toString());
-        assertEquals(" $ 1.20", new Money(120).toString());
-        assertEquals(" $ 1.23", new Money(123).toString());
+    public void getMoneyFromNegativeValue_fails_throwsMoneyException() {
+        assertThrows(MoneyException.class, () -> new Money(-123));
     }
 
     @Test
-    public void testFullCentsString() {
-        assertEquals(" $ 1.23", new Money(123).toString());
-        assertEquals("-$ 1.23", new Money(-123).toString());
+    public void checkMoneyOutput() throws MoneyException {
+        assertEquals("$ 1.00", new Money(100).toString());
+        assertEquals("$ 3.00", new Money(300).toString());
+        assertEquals("$ 1.20", new Money(120).toString());
+        assertEquals("$ 1.23", new Money(123).toString());
     }
 
     @Test
-    public void testPaddedCentsString() {
-        assertEquals(" $ 1.03", new Money(103).toString());
-        assertEquals("-$ 1.03", new Money(-103).toString());
+    public void testFullCentsString() throws MoneyException {
+        assertEquals("$ 1.23", new Money(123).toString());
     }
 
     @Test
-    public void testOnlyCentsString() {
-        assertEquals(" $ 0.03", new Money(3).toString());
-        assertEquals("-$ 0.03", new Money(-3).toString());
+    public void testPaddedCentsString() throws MoneyException {
+        assertEquals("$ 1.03", new Money(103).toString());
     }
 
     @Test
-    public void mathTest() throws Money.MoneyException {
+    public void testOnlyCentsString() throws MoneyException {
+        assertEquals("$ 0.03", new Money(3).toString());
+        assertEquals("$ 0.00", new Money(0).toString());
+    }
+
+    @Test
+    public void mathTest() throws MoneyException {
         Money oneCent = new Money(1);
         Money oneDollar = new Money(100);
         assertEquals(101, Money.add(oneCent, oneDollar).getValue());
         assertEquals(99, Money.subtract(oneDollar, oneCent).getValue());
-        assertEquals(-99, Money.subtract(oneCent, oneDollar).getValue());
     }
 
     @Test
-    public void safeMaths() {
+    public void safeMaths() throws MoneyException {
         Money maxValue = new Money(Long.MAX_VALUE);
-        Money minValue = new Money(Long.MIN_VALUE);
+        Money minValue = new Money(0);
         Money oneCent = new Money(1);
-        assertThrows(Money.MoneyException.class, () -> Money.add(maxValue, oneCent));
-        assertThrows(Money.MoneyException.class, () -> Money.subtract(minValue, oneCent));
+        assertThrows(MoneyException.class, () -> Money.add(maxValue, oneCent));
+        assertThrows(MoneyException.class, () -> Money.subtract(minValue, oneCent));
+        assertThrows(MoneyException.class, () -> Money.subtract(new Money(1), new Money(100)));
     }
 
     @Test
-    public void equals() {
+    public void equals() throws MoneyException {
         Money oneDollar = new Money(100);
         Money oneDollarAgain = new Money(100);
-        Money negativeOneDollar = new Money(-100);
-        Money negativeOneDollarAgain = new Money(-100);
 
         assertEquals(oneDollar, oneDollar);
         assertEquals(oneDollar, oneDollarAgain);
         assertEquals(oneDollar.getValue(), oneDollarAgain.getValue());
         assertEquals(oneDollar.toString(), oneDollarAgain.toString());
-
-        assertNotEquals(negativeOneDollar, oneDollar);
-
-        assertEquals(negativeOneDollar, negativeOneDollar);
-        assertEquals(negativeOneDollar, negativeOneDollarAgain);
-        assertEquals(negativeOneDollar.getValue(), negativeOneDollarAgain.getValue());
-        assertEquals(negativeOneDollar.toString(), negativeOneDollarAgain.toString());
     }
 }

--- a/src/test/java/donnafin/logic/parser/ParserUtilTest.java
+++ b/src/test/java/donnafin/logic/parser/ParserUtilTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.types.Money;
+import donnafin.commons.core.types.Money.MoneyException;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.model.person.Address;
 import donnafin.model.person.Email;
@@ -202,13 +203,13 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseMoney_validWithDollarSign() throws ParseException {
+    public void parseMoney_validWithDollarSign() throws ParseException, MoneyException {
         assertEquals(new Money(100), ParserUtil.parseMoney("$1"));
         assertEquals(new Money(100000), ParserUtil.parseMoney("$1000"));
     }
 
     @Test
-    public void parseMoney_validWithDollarSignCents() throws ParseException {
+    public void parseMoney_validWithDollarSignCents() throws ParseException, MoneyException {
         assertEquals(new Money(105), ParserUtil.parseMoney("$1.05"));
     }
 
@@ -219,7 +220,7 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseMoney_validWithWhiteSpace() throws ParseException {
+    public void parseMoney_validWithWhiteSpace() throws ParseException, MoneyException {
         // trailing whitespace
         assertEquals(new Money(100), ParserUtil.parseMoney("  $1  "));
         assertEquals(new Money(105), ParserUtil.parseMoney("  $1.05  "));
@@ -230,25 +231,10 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseMoney_validWithNegative() throws ParseException {
-        // trailing whitespace
-        assertEquals(new Money(-100), ParserUtil.parseMoney("-$1"));
-        assertEquals(new Money(-105), ParserUtil.parseMoney("-$1.05"));
-
-        // whitespace after dollar sign
-        assertEquals(new Money(-100), ParserUtil.parseMoney("-$1"));
-        assertEquals(new Money(-105), ParserUtil.parseMoney("-$1.05"));
-    }
-
-    @Test
-    public void parseMoney_validWithNegativeAndWhiteSpace() throws ParseException {
-        // trailing whitespace
-        assertEquals(new Money(-100), ParserUtil.parseMoney(" - $1  "));
-        assertEquals(new Money(-105), ParserUtil.parseMoney(" - $1.05  "));
-
-        // whitespace after dollar sign
-        assertEquals(new Money(-100), ParserUtil.parseMoney("  -  $  1"));
-        assertEquals(new Money(-105), ParserUtil.parseMoney(" -  $    1.05"));
+    public void parseMoney_invalidWithNegative() throws ParseException {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("-$1.00"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("-$1"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("- $1"));
     }
 
     @Test
@@ -268,12 +254,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseMoney_testBigValues() throws ParseException {
-        assertEquals(" $ 100000000.00", ParserUtil.parseMoney("$ 100000000").toString());
-        assertEquals("-$ 100000000.00", ParserUtil.parseMoney("-$ 100000000").toString());
-        assertEquals(" $ 1000000000.00", ParserUtil.parseMoney("$ 1000000000").toString());
-        assertEquals("-$ 1000000000.00", ParserUtil.parseMoney("-$ 1000000000").toString());
-        assertEquals(" $ 92233720368547758.00", ParserUtil.parseMoney("$" + (Long.MAX_VALUE / 100)).toString());
-        assertEquals("-$ 92233720368547758.00", ParserUtil.parseMoney("-$" + (Long.MAX_VALUE / 100)).toString());
+        assertEquals("$ 100000000.00", ParserUtil.parseMoney("$ 100000000").toString());
+        assertEquals("$ 1000000000.00", ParserUtil.parseMoney("$ 1000000000").toString());
+        assertEquals("$ 92233720368547758.00", ParserUtil.parseMoney("$" + (Long.MAX_VALUE / 100)).toString());
         assertThrows(ParseException.class, () -> ParserUtil.parseMoney("$" + (Long.MAX_VALUE / 100) + 1));
     }
 

--- a/src/test/java/donnafin/model/person/AssetTest.java
+++ b/src/test/java/donnafin/model/person/AssetTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.types.Money;
+import donnafin.commons.core.types.Money.MoneyException;
 
 public class AssetTest {
 
@@ -79,7 +80,7 @@ public class AssetTest {
     }
 
     @Test
-    public void variable_commissionToString_valid() {
+    public void variable_commissionToString_valid() throws MoneyException {
         Money value = new Money(200000);
         assertEquals(value.toString(), VALID_ASSET.getValueToString());
     }

--- a/src/test/java/donnafin/model/person/EmailTest.java
+++ b/src/test/java/donnafin/model/person/EmailTest.java
@@ -15,8 +15,10 @@ public class EmailTest {
 
     @Test
     public void constructor_invalidEmail_throwsIllegalArgumentException() {
-        String invalidEmail = "";
-        assertThrows(IllegalArgumentException.class, () -> new Email(invalidEmail));
+        String empty = "";
+        String noTld = "test@test";
+        assertThrows(IllegalArgumentException.class, () -> new Email(empty));
+        assertThrows(IllegalArgumentException.class, () -> new Email(noTld));
     }
 
     @Test
@@ -52,17 +54,21 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
 
+        // emails that are not accessible by typical mail clients over the internet
+        assertFalse(Email.isValidEmail("a@bc")); // minimal
+        assertFalse(Email.isValidEmail("test@localhost")); // alphabets only
+        assertFalse(Email.isValidEmail("test@")); // alphabets only
+        assertFalse(Email.isValidEmail("123@145")); // numeric local part and domain name
+
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("e1234567@u.new-college-nus.edu")); // hyphens within domain name
     }
 }

--- a/src/test/java/donnafin/model/person/LiabilityTest.java
+++ b/src/test/java/donnafin/model/person/LiabilityTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.types.Money;
+import donnafin.commons.core.types.Money.MoneyException;
 
 public class LiabilityTest {
     private static final String VALID_NAME = "Mortgage debt";
@@ -78,7 +79,7 @@ public class LiabilityTest {
     }
 
     @Test
-    public void variable_commissionToString_valid() {
+    public void variable_commissionToString_valid() throws MoneyException {
         Money value = new Money(200000);
         assertEquals(value.toString(), VALID_LIABILITY.getValueToString());
     }

--- a/src/test/java/donnafin/model/person/PolicyTest.java
+++ b/src/test/java/donnafin/model/person/PolicyTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import donnafin.commons.core.types.Money;
+import donnafin.commons.core.types.Money.MoneyException;
 
 public class PolicyTest {
 
@@ -99,19 +100,19 @@ public class PolicyTest {
     }
 
     @Test
-    public void variable_commissionToString_valid() {
+    public void variable_commissionToString_valid() throws MoneyException {
         Money commission = new Money(20000);
         assertEquals(commission.toString(), VALID_POLICY.getCommissionToString());
     }
 
     @Test
-    public void variable_yearlyPremiumsToString_valid() {
+    public void variable_yearlyPremiumsToString_valid() throws MoneyException {
         Money yearlyPremiums = new Money(10000);
         assertEquals(yearlyPremiums.toString(), VALID_POLICY.getYearlyPremiumsToString());
     }
 
     @Test
-    public void variable_totalValueInsuredToString_valid() {
+    public void variable_totalValueInsuredToString_valid() throws MoneyException {
         Money totalValueInsured = new Money(200000);
         assertEquals(totalValueInsured.toString(), VALID_POLICY.getTotalValueInsuredToString());
     }

--- a/src/test/java/donnafin/ui/PersonListPanelTest.java
+++ b/src/test/java/donnafin/ui/PersonListPanelTest.java
@@ -71,7 +71,7 @@ public class PersonListPanelTest extends GuiUnitTest {
         for (int i = 0; i < personCount; i++) {
             Name name = new Name(i + "a");
             Phone phone = new Phone("000");
-            Email email = new Email("a@aa");
+            Email email = new Email("a@aa.aa");
             Address address = new Address("a");
             Person person = new Person(name, phone, email, address, Collections.emptySet(), new Notes(""),
                     Collections.emptySet(), Collections.emptySet(), Collections.emptySet());

--- a/src/test/java/donnafin/ui/PolicyTestTable.java
+++ b/src/test/java/donnafin/ui/PolicyTestTable.java
@@ -13,8 +13,8 @@ public class PolicyTestTable {
                     .reduce(0.0, Double::sum)
         );
     private static final List<AttributeTable.ColumnConfig> columnConfigs = List.of(
-            new AttributeTable.ColumnConfig("Policy Name", "name", 400),
-            new AttributeTable.ColumnConfig("Value", "amt", 100)
+            new AttributeTable.ColumnConfig("Policy Name", "name", 400, 400),
+            new AttributeTable.ColumnConfig("Value", "amt", 100, 100)
     );
 
     private static final AttributeTable.TableConfig<PolicyTest> tableConfig = new AttributeTable.TableConfig<>(


### PR DESCRIPTION
### Use `BigInteger` to solve Money overflow in table. 42df9a3

Fixes #209

### Add proper message constraints for attributes. 9766666

Fixes #231

### Disable sorting for `AttributeTable` columns. 554fedc

Fixes #217

### Change column widths and default window size and hides index column header. 4a4cd45

Fixes #232
Fixes #214

- Note that the default window size is bigger to see all columns (may need to `gradlew clean` to see effect)

### Revert all negative support in `Money`. c410a96

Fixes #208

### Add FAQ to explain duplicate names & alternative scripts / currencies 6727150

Fixes #202
and adds in FAQ for users interested in multicurrency or annoyed at our
(module given) constraint against multiple people with the same name.

### Drop support for emails without TLD. 8497174

Reasoning:
emails without .com / .edu / etc are not accessible over the internet by any mail client. The typical example used is email@localhost, which obviously requires you to email to a local mail server.

This use case would not exist for our app catering to financial advisors keeping track of their clients.

Fixes #238 



