### PR TITLE
Ignore mixed case, double / trailing space in attr

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -57,6 +57,12 @@ Note: From here on we shall refer to DonnaFin.io as DonnaFin for your readabilit
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
+* If the parameters are simple (not multiline), Donnafin will take care of any accidental double or trailing spaces<br>
+  e.g. "a/ Sun   Glade @ West Coast "  is the same as "a/Sun Glade @ West Coast" but not the same as "a/SunGlade @ WestCoast"
+
+* When adding new clients or adding a policy, asset or liability to a client, Donnafin ignores case and double or trailing spaces when checking for duplicates<br>
+  e.g. An existing client with the name "John Wayne" prevents you from adding "john  wayne "
+
 * If a parameter is expected only once in the command but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
   e.g. if you specify `p/12341234 p/56785678`, only `p/56785678` will be taken.
 

--- a/src/main/java/donnafin/model/person/Address.java
+++ b/src/main/java/donnafin/model/person/Address.java
@@ -26,6 +26,7 @@ public class Address implements Attribute {
      */
     public Address(String address) {
         requireNonNull(address);
+        address = address.trim().replaceAll("\\s\\s+", " ");
         checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
         value = address;
     }
@@ -46,7 +47,7 @@ public class Address implements Attribute {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Address // instanceof handles nulls
-                && value.equals(((Address) other).value)); // state check
+                && value.equalsIgnoreCase(((Address) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Asset.java
+++ b/src/main/java/donnafin/model/person/Asset.java
@@ -71,14 +71,14 @@ public class Asset implements Attribute {
         checkArgument(isValidVariable(name), MESSAGE_CONSTRAINTS);
         checkArgument(isValidVariable(type), MESSAGE_CONSTRAINTS);
         checkArgument(isValidVariable(remarks), MESSAGE_CONSTRAINTS);
-        this.name = name;
-        this.type = type;
+        this.name = name.trim().replaceAll("\\s\\s+", " ");
+        this.type = type.trim().replaceAll("\\s\\s+", " ");
         try {
             this.value = ParserUtil.parseMoney(value);
         } catch (ParseException e) {
             throw new IllegalArgumentException(Money.MESSAGE_CONSTRAINTS);
         }
-        this.remarks = remarks;
+        this.remarks = remarks.trim().replaceAll("\\s\\s+", " ");
     }
 
     /**
@@ -109,10 +109,10 @@ public class Asset implements Attribute {
         }
 
         Asset asset = (Asset) o;
-        return getName().equals(asset.getName())
-                && getType().equals(asset.getType())
+        return getName().equalsIgnoreCase(asset.getName())
+                && getType().equalsIgnoreCase(asset.getType())
                 && getValue().equals(asset.getValue())
-                && getRemarks().equals(asset.getRemarks());
+                && getRemarks().equalsIgnoreCase(asset.getRemarks());
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Email.java
+++ b/src/main/java/donnafin/model/person/Email.java
@@ -40,6 +40,7 @@ public class Email implements Attribute {
      */
     public Email(String email) {
         requireNonNull(email);
+        email = email.trim().replaceAll("\\s\\s+", " ");
         checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);
         value = email;
     }
@@ -60,7 +61,7 @@ public class Email implements Attribute {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Email // instanceof handles nulls
-                && value.equals(((Email) other).value)); // state check
+                && value.equalsIgnoreCase(((Email) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Liability.java
+++ b/src/main/java/donnafin/model/person/Liability.java
@@ -71,14 +71,14 @@ public class Liability implements Attribute {
         checkArgument(isValidVariable(name), MESSAGE_CONSTRAINTS);
         checkArgument(isValidVariable(type), MESSAGE_CONSTRAINTS);
         checkArgument(isValidVariable(remarks), MESSAGE_CONSTRAINTS);
-        this.name = name;
-        this.type = type;
+        this.name = name.trim().replaceAll("\\s\\s+", " ");
+        this.type = type.trim().replaceAll("\\s\\s+", " ");
         try {
             this.value = ParserUtil.parseMoney(value);
         } catch (ParseException e) {
             throw new IllegalArgumentException(Money.MESSAGE_CONSTRAINTS);
         }
-        this.remarks = remarks;
+        this.remarks = remarks.trim().replaceAll("\\s\\s+", " ");
     }
 
     /**
@@ -109,10 +109,10 @@ public class Liability implements Attribute {
         }
 
         Liability liability = (Liability) o;
-        return getName().equals(liability.getName())
-                && getType().equals(liability.getType())
+        return getName().equalsIgnoreCase(liability.getName())
+                && getType().equalsIgnoreCase(liability.getType())
                 && getValue().equals(liability.getValue())
-                && getRemarks().equals(liability.getRemarks());
+                && getRemarks().equalsIgnoreCase(liability.getRemarks());
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Name.java
+++ b/src/main/java/donnafin/model/person/Name.java
@@ -27,6 +27,7 @@ public class Name implements Attribute {
      */
     public Name(String name) {
         requireNonNull(name);
+        name = name.trim().replaceAll("\\s\\s+", " ");
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
         fullName = name;
     }
@@ -48,7 +49,7 @@ public class Name implements Attribute {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && fullName.equalsIgnoreCase(((Name) other).fullName)); // state check
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Notes.java
+++ b/src/main/java/donnafin/model/person/Notes.java
@@ -45,7 +45,7 @@ public class Notes implements Attribute {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Notes // instanceof handles nulls
-                && notes.equals(((Notes) other).notes)); // state check
+                && notes.equalsIgnoreCase(((Notes) other).notes)); // state check
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Phone.java
+++ b/src/main/java/donnafin/model/person/Phone.java
@@ -22,6 +22,7 @@ public class Phone implements Attribute {
      */
     public Phone(String phone) {
         requireNonNull(phone);
+        phone = phone.trim().replaceAll("\\s\\s+", " ");
         checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
         value = phone;
     }
@@ -42,7 +43,7 @@ public class Phone implements Attribute {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Phone // instanceof handles nulls
-                && value.equals(((Phone) other).value)); // state check
+                && value.equalsIgnoreCase(((Phone) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/donnafin/model/person/Policy.java
+++ b/src/main/java/donnafin/model/person/Policy.java
@@ -76,8 +76,8 @@ public class Policy implements Attribute {
         requireAllNonNull(name, insurer, totalValueInsured, yearlyPremiums, commission);
         checkArgument(isValidVariable(name), MESSAGE_CONSTRAINTS);
         checkArgument(isValidVariable(insurer), MESSAGE_CONSTRAINTS);
-        this.name = name;
-        this.insurer = insurer;
+        this.name = name.trim().replaceAll("\\s\\s+", " ");
+        this.insurer = insurer.trim().replaceAll("\\s\\s+", " ");
         try {
             this.totalValueInsured = ParserUtil.parseMoney(totalValueInsured);
             this.yearlyPremiums = ParserUtil.parseMoney(yearlyPremiums);
@@ -116,8 +116,8 @@ public class Policy implements Attribute {
         }
 
         Policy policy = (Policy) o;
-        return getName().equals(policy.getName())
-                && getInsurer().equals(policy.getInsurer())
+        return getName().equalsIgnoreCase(policy.getName())
+                && getInsurer().equalsIgnoreCase(policy.getInsurer())
                 && getTotalValueInsured().equals(policy.getTotalValueInsured())
                 && getYearlyPremiums().equals(policy.getYearlyPremiums())
                 && getCommission().equals(policy.getCommission());

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -30,7 +30,7 @@
         }
       ]
   }, {
-    "name": "Alice Pauline",
+    "name": "alice  pauline ",
     "phone": "94351253",
     "email": "pauline@example.com",
     "address": "4th street",

--- a/src/test/java/donnafin/model/person/AssetTest.java
+++ b/src/test/java/donnafin/model/person/AssetTest.java
@@ -92,7 +92,9 @@ public class AssetTest {
     public void testEquals() {
         final Asset sameAsset = new Asset(VALID_NAME, VALID_TYPE, VALID_VALUE, VALID_REMARKS);
         final Asset otherAsset = new Asset(VALID_NAME + " something", VALID_TYPE, VALID_VALUE, VALID_REMARKS);
+        assertEquals(VALID_ASSET, VALID_ASSET);
         assertEquals(sameAsset, VALID_ASSET);
+        assertNotEquals(sameAsset, "a string");
         assertNotEquals(otherAsset, sameAsset);
         assertNotEquals(null, sameAsset);
     }

--- a/src/test/java/donnafin/model/person/LiabilityTest.java
+++ b/src/test/java/donnafin/model/person/LiabilityTest.java
@@ -92,7 +92,9 @@ public class LiabilityTest {
         final Liability sameLiability = new Liability(VALID_NAME, VALID_TYPE, VALID_VALUE, VALID_REMARKS);
         final Liability otherLiability =
                 new Liability(VALID_NAME + " something", VALID_TYPE, VALID_VALUE, VALID_REMARKS);
+        assertEquals(VALID_LIABILITY, VALID_LIABILITY);
         assertEquals(sameLiability, VALID_LIABILITY);
+        assertNotEquals(sameLiability, "a string");
         assertNotEquals(otherLiability, sameLiability);
         assertNotEquals(null, sameLiability);
     }

--- a/src/test/java/donnafin/model/person/NameTest.java
+++ b/src/test/java/donnafin/model/person/NameTest.java
@@ -32,6 +32,7 @@ public class NameTest {
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
+        assertTrue(Name.isValidName("Peter  Jack")); // contains non-alphanumeric characters
         assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters

--- a/src/test/java/donnafin/model/person/PersonTest.java
+++ b/src/test/java/donnafin/model/person/PersonTest.java
@@ -36,14 +36,19 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
+
+        // name has double spaces, all other attributes same -> returns true
+        String nameWithDoubleSpaces = VALID_NAME_BOB.replace(" ", "  ");
+        editedBob = new PersonBuilder(BOB).withName(nameWithDoubleSpaces).build();
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/donnafin/model/person/PolicyTest.java
+++ b/src/test/java/donnafin/model/person/PolicyTest.java
@@ -130,7 +130,9 @@ public class PolicyTest {
                 VALID_NAME + "something", VALID_INSURER, VALID_TOTAL_VALUE_INSURED,
                 VALID_YEARLY_PREMIUMS, VALID_COMMISSION
         );
+        assertEquals(VALID_POLICY, VALID_POLICY);
         assertEquals(samePolicy, VALID_POLICY);
+        assertNotEquals(samePolicy, "a string");
         assertNotEquals(otherPolicy, samePolicy);
         assertNotEquals(null, samePolicy);
     }


### PR DESCRIPTION
This means "Muhammad Ali" is the same as "muhammad  ali ", and the same
applies for emails, address, phone, policy names, policy insurer name,
asset name, asset type, etc. Only exception is Notes because that is
multiline and there is a case to be made for protecting multiple spaces
(e.g. as an indent)

This resolves bugs of duplicating names through sneaky json edits, and even
adding policies of very similar names etc

E.g:

Fixes #228 

# ⚠️  see telegram discussion