### PR TITLE
Fix PED Issue #220

### DIFF
--- a/src/main/java/donnafin/commons/core/Messages.java
+++ b/src/main/java/donnafin/commons/core/Messages.java
@@ -11,6 +11,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSON_LISTED_OVERVIEW = "1 person listed!";
+    public static final String MESSAGE_NO_PERSON_LISTED_OVERVIEW = "No person listed!";
     public static final String MESSAGE_USE_HELP_COMMAND = String.format(
             "Invalid command format! Try using the help command. \n%1$s", HelpCommand.MESSAGE_USAGE);
 

--- a/src/main/java/donnafin/logic/commands/FindCommand.java
+++ b/src/main/java/donnafin/logic/commands/FindCommand.java
@@ -29,6 +29,13 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        if (model.getFilteredPersonList().size() < 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_NO_PERSON_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        } else if (model.getFilteredPersonList().size() == 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_PERSON_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/test/java/donnafin/logic/commands/FindCommandTest.java
+++ b/src/test/java/donnafin/logic/commands/FindCommandTest.java
@@ -1,6 +1,8 @@
 package donnafin.logic.commands;
 
+import static donnafin.commons.core.Messages.MESSAGE_NO_PERSON_LISTED_OVERVIEW;
 import static donnafin.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static donnafin.commons.core.Messages.MESSAGE_PERSON_LISTED_OVERVIEW;
 import static donnafin.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static donnafin.testutil.TypicalPersons.CARL;
 import static donnafin.testutil.TypicalPersons.ELLE;
@@ -55,12 +57,22 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_NO_PERSON_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneKeywords_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSON_LISTED_OVERVIEW);
+        NameContainsKeywordsPredicate predicate = preparePredicate("Carl");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredPersonList());
     }
 
     @Test


### PR DESCRIPTION
Fix PED Issue #220 where persons is shown instead of person when 1 person is returned from the find command. A special case was made for 0 persons returned as well. 

Test cases for FindCommandTest has been updated as well.

Original: 
![image](https://user-images.githubusercontent.com/77235299/139824251-a8155396-ea00-450c-9899-214c2fbff265.png)
![image](https://user-images.githubusercontent.com/77235299/139824300-3e3c5021-5348-4bc9-a02c-99b4056880c8.png)

Updated:
![image](https://user-images.githubusercontent.com/77235299/139824464-09732a17-2f06-4c7d-a7ea-8d62721b4f33.png)
![image](https://user-images.githubusercontent.com/77235299/139824487-9656bf46-9b8d-4de2-a0ef-fd1ff9a5c501.png)

#220 
