### PR TITLE
valid command word in wrong window/tab shows appropriate error message

### DIFF
--- a/src/main/java/donnafin/commons/core/Messages.java
+++ b/src/main/java/donnafin/commons/core/Messages.java
@@ -1,5 +1,6 @@
 package donnafin.commons.core;
 
+import donnafin.logic.commands.EditCommand;
 import donnafin.logic.commands.HelpCommand;
 
 /**
@@ -19,5 +20,9 @@ public class Messages {
     public static final String MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW = "This is a home window command and is not "
             + "available in client window!\nTry using the home command to access home window commands."
             + "\nRefer to our user guide for more info.";
-
+    public static final String MESSAGE_EDIT_COMMAND_UNAVAILABLE = "Editing is not supported in current version of "
+            + "DonnaFin.\nSupport for editing will be coming soon!";
+    public static final String MESSAGE_EDIT_COMMAND_SUPPORTED = String.format(
+            "Append and Remove commands are unavailable but Edit command is supported for Contacts.\n%1$s",
+            EditCommand.MESSAGE_USAGE);
 }

--- a/src/main/java/donnafin/commons/core/Messages.java
+++ b/src/main/java/donnafin/commons/core/Messages.java
@@ -23,6 +23,8 @@ public class Messages {
     public static final String MESSAGE_EDIT_COMMAND_UNAVAILABLE = "Editing is not supported in current version of "
             + "DonnaFin.\nSupport for editing will be coming soon!";
     public static final String MESSAGE_EDIT_COMMAND_SUPPORTED = String.format(
-            "Append and Remove commands are unavailable but Edit command is supported for Contacts.\n%1$s",
+            "Append and Remove commands are unavailable but the Edit command is supported for Contacts.\n%1$s",
             EditCommand.MESSAGE_USAGE);
+    public static final String MESSAGE_NO_CLIENTWINDOW_COMMANDS_SUPPORTED = "Append, Remove and Edit commands are "
+            + "not supported in the Notes tab.\nYou may add your changes directly in the text box below.";
 }

--- a/src/main/java/donnafin/commons/core/Messages.java
+++ b/src/main/java/donnafin/commons/core/Messages.java
@@ -13,5 +13,11 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_USE_HELP_COMMAND = String.format(
             "Invalid command format! Try using the help command. \n%1$s", HelpCommand.MESSAGE_USAGE);
+    public static final String MESSAGE_COMMAND_NOT_IN_HOMEWINDOW = "This is a client window command and is not "
+            + "available in home window!\nTry using the view command to access client window commands."
+            + "\nRefer to our user guide for more info.";
+    public static final String MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW = "This is a home window command and is not "
+            + "available in client window!\nTry using the home command to access home window commands."
+            + "\nRefer to our user guide for more info.";
 
 }

--- a/src/main/java/donnafin/logic/commands/ContactTabParser.java
+++ b/src/main/java/donnafin/logic/commands/ContactTabParser.java
@@ -2,9 +2,12 @@ package donnafin.logic.commands;
 
 import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
+import donnafin.logic.parser.AppendCommandParser;
 import donnafin.logic.parser.ClientViewParser;
 import donnafin.logic.parser.EditCommandParser;
+import donnafin.logic.parser.RemoveCommandParser;
 import donnafin.logic.parser.exceptions.ParseException;
+import donnafin.ui.Ui;
 
 public class ContactTabParser extends ClientViewParser {
 
@@ -17,6 +20,13 @@ public class ContactTabParser extends ClientViewParser {
         switch (commandWord) {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser(personAdapter).parse(arguments);
+
+        case AppendCommand.COMMAND_WORD:
+            //fallthrough
+
+        case RemoveCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_SUPPORTED);
+
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/donnafin/logic/commands/ContactTabParser.java
+++ b/src/main/java/donnafin/logic/commands/ContactTabParser.java
@@ -2,12 +2,9 @@ package donnafin.logic.commands;
 
 import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
-import donnafin.logic.parser.AppendCommandParser;
 import donnafin.logic.parser.ClientViewParser;
 import donnafin.logic.parser.EditCommandParser;
-import donnafin.logic.parser.RemoveCommandParser;
 import donnafin.logic.parser.exceptions.ParseException;
-import donnafin.ui.Ui;
 
 public class ContactTabParser extends ClientViewParser {
 

--- a/src/main/java/donnafin/logic/commands/EditCommand.java
+++ b/src/main/java/donnafin/logic/commands/EditCommand.java
@@ -29,8 +29,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "Example: " + COMMAND_WORD
+            + "[" + PREFIX_ADDRESS + "ADDRESS]\n"
+            + "Example: " + COMMAND_WORD + " "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 

--- a/src/main/java/donnafin/logic/commands/NotesTabParser.java
+++ b/src/main/java/donnafin/logic/commands/NotesTabParser.java
@@ -14,11 +14,17 @@ public class NotesTabParser extends ClientViewParser {
     @Override
     protected Command tabSpecificHandler(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
-        case "INSERT COMMAND WORD FOR EDIT HERE":
-            //TODO
+        case AppendCommand.COMMAND_WORD:
+            //fallthrough
+
+        case RemoveCommand.COMMAND_WORD:
+            //fallthrough
+
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_NO_CLIENTWINDOW_COMMANDS_SUPPORTED);
+
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
         }
-
     }
 }

--- a/src/main/java/donnafin/logic/parser/AddressBookParser.java
+++ b/src/main/java/donnafin/logic/parser/AddressBookParser.java
@@ -2,13 +2,18 @@ package donnafin.logic.parser;
 
 import donnafin.commons.core.Messages;
 import donnafin.logic.commands.AddCommand;
+import donnafin.logic.commands.AppendCommand;
 import donnafin.logic.commands.ClearCommand;
 import donnafin.logic.commands.Command;
 import donnafin.logic.commands.DeleteCommand;
+import donnafin.logic.commands.EditCommand;
 import donnafin.logic.commands.ExitCommand;
 import donnafin.logic.commands.FindCommand;
 import donnafin.logic.commands.HelpCommand;
+import donnafin.logic.commands.HomeCommand;
 import donnafin.logic.commands.ListCommand;
+import donnafin.logic.commands.RemoveCommand;
+import donnafin.logic.commands.SwitchTabCommand;
 import donnafin.logic.commands.ViewCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 
@@ -48,6 +53,21 @@ public final class AddressBookParser extends ParserStrategy {
 
         case HelpCommand.COMMAND_WORD:
             return !arguments.equals("") ? throwsInvalidInputMsg() : new HelpCommand();
+
+        case HomeCommand.COMMAND_WORD:
+            return !arguments.equals("") ? throwsInvalidInputMsg() : new HomeCommand();
+
+        case AppendCommand.COMMAND_WORD:
+            //fallthrough
+
+        case RemoveCommand.COMMAND_WORD:
+            //fallthrough
+
+        case EditCommand.COMMAND_WORD:
+            //fallthrough
+
+        case SwitchTabCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_COMMAND_NOT_IN_HOMEWINDOW);
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/donnafin/logic/parser/AssetsTabParser.java
+++ b/src/main/java/donnafin/logic/parser/AssetsTabParser.java
@@ -4,6 +4,7 @@ import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
 import donnafin.logic.commands.AppendCommand;
 import donnafin.logic.commands.Command;
+import donnafin.logic.commands.EditCommand;
 import donnafin.logic.commands.RemoveCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.ui.Ui;
@@ -19,10 +20,14 @@ public class AssetsTabParser extends ClientViewParser {
         switch (commandWord) {
         case AppendCommand.COMMAND_WORD:
             return new AppendCommandParser(Ui.ViewFinderState.ASSETS, super.personAdapter).parse(arguments);
+
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser(Ui.ViewFinderState.ASSETS, super.personAdapter).parse(arguments);
-        case "EDIT": // parse the rest of it
-        default: // throw error
+
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
+
+        default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/donnafin/logic/parser/ClientViewParser.java
+++ b/src/main/java/donnafin/logic/parser/ClientViewParser.java
@@ -2,12 +2,19 @@ package donnafin.logic.parser;
 
 import java.util.Objects;
 
+import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
+import donnafin.logic.commands.AddCommand;
+import donnafin.logic.commands.ClearCommand;
 import donnafin.logic.commands.Command;
+import donnafin.logic.commands.DeleteCommand;
 import donnafin.logic.commands.ExitCommand;
+import donnafin.logic.commands.FindCommand;
 import donnafin.logic.commands.HelpCommand;
 import donnafin.logic.commands.HomeCommand;
+import donnafin.logic.commands.ListCommand;
 import donnafin.logic.commands.SwitchTabCommand;
+import donnafin.logic.commands.ViewCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 
 public abstract class ClientViewParser extends ParserStrategy {
@@ -38,6 +45,24 @@ public abstract class ClientViewParser extends ParserStrategy {
 
         case SwitchTabCommand.COMMAND_WORD:
             return new SwitchTabCommand(ParserUtil.parseTab(arguments), personAdapter);
+
+        case AddCommand.COMMAND_WORD:
+            //fallthrough
+
+        case DeleteCommand.COMMAND_WORD:
+            //fallthrough
+
+        case ClearCommand.COMMAND_WORD:
+            //fallthrough
+
+        case FindCommand.COMMAND_WORD:
+            //fallthrough
+
+        case ListCommand.COMMAND_WORD:
+            //fallthrough
+
+        case ViewCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW);
 
         default:
             return tabSpecificHandler(commandWord, arguments);

--- a/src/main/java/donnafin/logic/parser/LiabilitiesTabParser.java
+++ b/src/main/java/donnafin/logic/parser/LiabilitiesTabParser.java
@@ -4,6 +4,7 @@ import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
 import donnafin.logic.commands.AppendCommand;
 import donnafin.logic.commands.Command;
+import donnafin.logic.commands.EditCommand;
 import donnafin.logic.commands.RemoveCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.ui.Ui;
@@ -17,11 +18,16 @@ public class LiabilitiesTabParser extends ClientViewParser {
     @Override
     protected Command tabSpecificHandler(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
+
         case AppendCommand.COMMAND_WORD:
             return new AppendCommandParser(Ui.ViewFinderState.LIABILITIES, super.personAdapter).parse(arguments);
+
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser(Ui.ViewFinderState.LIABILITIES, super.personAdapter).parse(arguments);
-        default: // throw error
+
+        default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/donnafin/logic/parser/LiabilitiesTabParser.java
+++ b/src/main/java/donnafin/logic/parser/LiabilitiesTabParser.java
@@ -18,14 +18,15 @@ public class LiabilitiesTabParser extends ClientViewParser {
     @Override
     protected Command tabSpecificHandler(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
-        case EditCommand.COMMAND_WORD:
-            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
 
         case AppendCommand.COMMAND_WORD:
             return new AppendCommandParser(Ui.ViewFinderState.LIABILITIES, super.personAdapter).parse(arguments);
 
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser(Ui.ViewFinderState.LIABILITIES, super.personAdapter).parse(arguments);
+
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/donnafin/logic/parser/PolicyTabParser.java
+++ b/src/main/java/donnafin/logic/parser/PolicyTabParser.java
@@ -18,14 +18,15 @@ public class PolicyTabParser extends ClientViewParser {
     @Override
     protected Command tabSpecificHandler(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
-        case EditCommand.COMMAND_WORD:
-            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
 
         case AppendCommand.COMMAND_WORD:
             return new AppendCommandParser(Ui.ViewFinderState.POLICIES, super.personAdapter).parse(arguments);
 
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser(Ui.ViewFinderState.POLICIES, super.personAdapter).parse(arguments);
+
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/donnafin/logic/parser/PolicyTabParser.java
+++ b/src/main/java/donnafin/logic/parser/PolicyTabParser.java
@@ -4,6 +4,7 @@ import donnafin.commons.core.Messages;
 import donnafin.logic.PersonAdapter;
 import donnafin.logic.commands.AppendCommand;
 import donnafin.logic.commands.Command;
+import donnafin.logic.commands.EditCommand;
 import donnafin.logic.commands.RemoveCommand;
 import donnafin.logic.parser.exceptions.ParseException;
 import donnafin.ui.Ui;
@@ -17,11 +18,16 @@ public class PolicyTabParser extends ClientViewParser {
     @Override
     protected Command tabSpecificHandler(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
+        case EditCommand.COMMAND_WORD:
+            throw new ParseException(Messages.MESSAGE_EDIT_COMMAND_UNAVAILABLE);
+
         case AppendCommand.COMMAND_WORD:
             return new AppendCommandParser(Ui.ViewFinderState.POLICIES, super.personAdapter).parse(arguments);
+
         case RemoveCommand.COMMAND_WORD:
             return new RemoveCommandParser(Ui.ViewFinderState.POLICIES, super.personAdapter).parse(arguments);
-        default: // throw error
+
+        default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/test/java/donnafin/logic/parser/AddressBookParserContextTest.java
+++ b/src/test/java/donnafin/logic/parser/AddressBookParserContextTest.java
@@ -122,13 +122,11 @@ public class AddressBookParserContextTest {
             -> parserContext.executeParserStrategyCommand("unknownCommand"));
     }
 
-    //From here on out it should we will clientParser fails
     @Test
     public void executeParserStrategyCommand_clientParserHome() throws Exception {
         assertTrue(strategyIsAddressBookParser());
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
-            -> parserContext.executeParserStrategyCommand(HomeCommand.COMMAND_WORD));
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+        assertTrue(parserContext.executeParserStrategyCommand(HomeCommand.COMMAND_WORD) instanceof HomeCommand);
+        assertThrows(ParseException.class, MESSAGE_USE_HELP_COMMAND, ()
             -> parserContext.executeParserStrategyCommand(
                HomeCommand.COMMAND_WORD + " 3"));
     }

--- a/src/test/java/donnafin/logic/parser/ClientViewParserContextTest.java
+++ b/src/test/java/donnafin/logic/parser/ClientViewParserContextTest.java
@@ -1,5 +1,6 @@
 package donnafin.logic.parser;
 
+import static donnafin.commons.core.Messages.MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW;
 import static donnafin.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static donnafin.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static donnafin.commons.core.Messages.MESSAGE_USE_HELP_COMMAND;
@@ -103,7 +104,7 @@ public class ClientViewParserContextTest {
     public void test_executeParserStrategyCommand_addressBookParserAdd() throws ParseException {
         Person person = new PersonBuilder().build();
         assertThrows(ParseException.class,
-            MESSAGE_UNKNOWN_COMMAND, ()
+                MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW, ()
                 -> parserContext.executeParserStrategyCommand(PersonUtil.getAddCommand(person)));
     }
 
@@ -111,7 +112,7 @@ public class ClientViewParserContextTest {
     @Test
     public void executeParserStrategyCommand_addressBookParserClear() throws Exception {
         assertThrows(ParseException.class,
-            MESSAGE_UNKNOWN_COMMAND, ()
+            MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW, ()
                 -> parserContext.executeParserStrategyCommand(ClearCommand.COMMAND_WORD));
         assertThrows(ParseException.class,
             MESSAGE_UNKNOWN_COMMAND, ()
@@ -121,7 +122,7 @@ public class ClientViewParserContextTest {
     @Test
     public void executeParserStrategyCommand_addressBookParserDelete() throws Exception {
         assertThrows(ParseException.class,
-            MESSAGE_UNKNOWN_COMMAND, ()
+            MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW, ()
                 -> parserContext.executeParserStrategyCommand(DeleteCommand.COMMAND_WORD));
         assertThrows(ParseException.class,
             MESSAGE_UNKNOWN_COMMAND, ()
@@ -133,14 +134,14 @@ public class ClientViewParserContextTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         String userInput = FindCommand.COMMAND_WORD + " " + String.join(" ", keywords);
         assertThrows(ParseException.class,
-            MESSAGE_UNKNOWN_COMMAND, ()
+            MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW, ()
                 -> parserContext.executeParserStrategyCommand(userInput));
     }
 
     @Test
     public void executeParserStrategyCommand_addressBookParserList() throws Exception {
         assertThrows(ParseException.class,
-            MESSAGE_UNKNOWN_COMMAND, ()
+            MESSAGE_COMMAND_NOT_IN_CLIENTWINDOW, ()
                 -> parserContext.executeParserStrategyCommand(ListCommand.COMMAND_WORD));
     }
 


### PR DESCRIPTION
Fixes #150 

Currently, a valid command word in wrong window/tab throws an "unknown command" error. Which is not true. 

Thus, if user uses client window commands in home window, an appropriate message is shown and vice versa.

The same logic is applied to tabs as contacts tab accepts only edit. while assets, liabilities, policies tab accept only append and remove on top of those inherited from client parser. notes tab will not accept additional commands.

Note that this PR will likely impact @mrmrinal incoming tests.