### PR TITLE
Reject starting zeroes in `parseMoney` if the value >= 1.

### DIFF
--- a/src/main/java/donnafin/commons/core/types/Money.java
+++ b/src/main/java/donnafin/commons/core/types/Money.java
@@ -8,7 +8,8 @@ public class Money {
     public static final String MONEY_ARITHMETIC_OVERFLOW =
             "Unable to calculate due to Integer limitations.";
     public static final String MESSAGE_CONSTRAINTS = "Monetary value fields should start with '$' followed by digits."
-            + " 2 digits preceded by a '.' may be added at the end to indicate cents";
+            + " 2 digits preceded by a '.' may be added at the end to indicate cents"
+            + "\nExample: '$2.40', or '$2'";
     private static final String CURRENCY_SYMBOL = "$";
     private static final int CURRENCY_EXPONENT = 2;
 

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -241,7 +241,7 @@ public class ParserUtil {
         if (!trimmedInput.matches(regexDollarCents)) {
             throw new ParseException(
                     String.format(
-                            "Input string '%s' does not match monetary value format. %s",
+                            "Input string '%s' does not match monetary value format.\n%s",
                             trimmedInput,
                             Money.MESSAGE_CONSTRAINTS)
             );

--- a/src/main/java/donnafin/logic/parser/ParserUtil.java
+++ b/src/main/java/donnafin/logic/parser/ParserUtil.java
@@ -235,7 +235,7 @@ public class ParserUtil {
         String trimmedInput = money.trim();
 
         // Handling Default currency $XYZ or $XYZ.AB
-        final String regexDollarCents = "^\\s*\\$\\s*\\d+(\\.\\d{2})?$";
+        final String regexDollarCents = "^\\s*\\$\\s*(([1-9]\\d*)|(0))(\\.\\d{2})?$";
         final String dollarCentsPrefix = "$";
 
         if (!trimmedInput.matches(regexDollarCents)) {

--- a/src/test/java/donnafin/logic/parser/ParserUtilTest.java
+++ b/src/test/java/donnafin/logic/parser/ParserUtilTest.java
@@ -184,6 +184,7 @@ public class ParserUtilTest {
     @Test
     public void parseMoney_invalidFormats() throws ParseException {
         assertThrows(ParseException.class, () -> ParserUtil.parseMoney("1.00$"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMoney("$01.00"));
         assertThrows(ParseException.class, () -> ParserUtil.parseMoney("$1.0.0"));
         assertThrows(ParseException.class, () -> ParserUtil.parseMoney("$.50"));
         assertThrows(ParseException.class, () -> ParserUtil.parseMoney("abc $2.50"));


### PR DESCRIPTION
Fixes AY2122S1-CS2103T-W16-1/tp#215

E.g. "$02.00" should be rejected, but not "$0.20"

Previously, "$02" was treated the same as "$2"